### PR TITLE
Add sccache to rust image

### DIFF
--- a/rust/buster/Dockerfile
+++ b/rust/buster/Dockerfile
@@ -23,7 +23,12 @@ ARG VERSION="stable"
 
 RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- -y --default-toolchain $VERSION --component clippy rustfmt --profile minimal --no-modify-path \
-    && cargo install cargo-audit \
     && chmod -R a+rw $RUSTUP_HOME $CARGO_HOME
+
+RUN cargo install cargo-audit
+
+RUN cargo install sccache
+
+ENV RUSTC_WRAPPER="/opt/rust/cargo/bin/sccache"
 
 CMD ["bash"]


### PR DESCRIPTION
Add [sccache](https://github.com/mozilla/sccache) to the rust build image to allow us to cache compile artifacts between builds.