### PR TITLE
Point sccache to a pre-release revision

### DIFF
--- a/rust/buster/Dockerfile
+++ b/rust/buster/Dockerfile
@@ -27,7 +27,7 @@ RUN curl https://sh.rustup.rs -sSf | \
 
 RUN cargo install cargo-audit
 
-RUN cargo install sccache
+RUN cargo install --git https://github.com/mozilla/sccache --rev 6628e1f70db3d583cb5e79210603ad878de3d315
 
 ENV RUSTC_WRAPPER="/opt/rust/cargo/bin/sccache"
 


### PR DESCRIPTION
This changes the dockerfile to install a more recent version of sccache which fixes an issue with cargo randomly timing out when it launches a lot of builds in parallel