### PR TITLE
Add systemd-dev as a dependency

### DIFF
--- a/rust/buster/Dockerfile
+++ b/rust/buster/Dockerfile
@@ -4,7 +4,7 @@ ENV CARGO_HOME="/opt/rust/cargo"
 ENV RUSTUP_HOME="/opt/rust/rustup"
 ENV PATH="${CARGO_HOME}/bin:${PATH}"
 
-RUN DEPS='gcc g++ make xz-utils locales libexpat1-dev gettext libz-dev libssl-dev autoconf pkg-config bzip2' \
+RUN DEPS='gcc g++ make xz-utils locales libexpat1-dev gettext libz-dev libssl-dev autoconf pkg-config bzip2 libsystemd-dev' \
   && apt-get update \
   && apt-get install -y --no-install-recommends $DEPS \
   && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \


### PR DESCRIPTION
This is to facilitate the addition of systemd in the upcoming 2.2 release of the logdna-agent.

Signed-off-by: Jacob Hull <jacob@planethull.com>