### PR TITLE
Add systemd lsof procps dependencies to rust buster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
         axes {
           axis {
             name 'RUST_VERSION'
-            values 'stable', 'beta', '1.42.0'
+            values 'stable', 'beta', '1.49.0'
           }
         }
 

--- a/rust/buster/Dockerfile
+++ b/rust/buster/Dockerfile
@@ -25,7 +25,7 @@ RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- -y --default-toolchain $VERSION --component clippy rustfmt --profile minimal --no-modify-path \
     && chmod -R a+rw $RUSTUP_HOME $CARGO_HOME
 
-RUN cargo install cargo-audit --version ~0.11
+RUN cargo install cargo-audit --version ~0.13
 
 RUN cargo install --git https://github.com/mozilla/sccache --rev 6628e1f70db3d583cb5e79210603ad878de3d315
 

--- a/rust/buster/Dockerfile
+++ b/rust/buster/Dockerfile
@@ -25,7 +25,7 @@ RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- -y --default-toolchain $VERSION --component clippy rustfmt --profile minimal --no-modify-path \
     && chmod -R a+rw $RUSTUP_HOME $CARGO_HOME
 
-RUN cargo install cargo-audit
+RUN cargo install cargo-audit --version ~0.11
 
 RUN cargo install --git https://github.com/mozilla/sccache --rev 6628e1f70db3d583cb5e79210603ad878de3d315
 

--- a/rust/buster/Dockerfile
+++ b/rust/buster/Dockerfile
@@ -4,7 +4,7 @@ ENV CARGO_HOME="/opt/rust/cargo"
 ENV RUSTUP_HOME="/opt/rust/rustup"
 ENV PATH="${CARGO_HOME}/bin:${PATH}"
 
-RUN DEPS='gcc g++ make xz-utils locales libexpat1-dev gettext libz-dev libssl-dev autoconf pkg-config bzip2 libsystemd-dev' \
+RUN DEPS='gcc g++ make xz-utils locales libexpat1-dev gettext libz-dev libssl-dev autoconf pkg-config bzip2 libsystemd-dev systemd lsof procps' \
   && apt-get update \
   && apt-get install -y --no-install-recommends $DEPS \
   && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \


### PR DESCRIPTION
Add `systemd`, `lsof` and `procps` (for `ps`) to rust dev image.