### PR TITLE
fix: helper script - "dirname: missing operand"

### DIFF
--- a/scripts/mk.debian
+++ b/scripts/mk.debian
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-TOP=$(dirname $(readlink "$0"))/..
+TOP=$(dirname $(readlink -f "$0"))/..
 pushd "$TOP"
 export DOCKER_BUILDKIT=1
 #

--- a/scripts/mk.debian.rebuild
+++ b/scripts/mk.debian.rebuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-TOP=$(dirname "$0")/..
+TOP=$(dirname -f "$0")/..
 pushd "$TOP"
 export SCCACHE_RECACHE=1
 export PULL_OPTS="--no-cache --pull"


### PR DESCRIPTION
fixed error:  "dirname: missing operand" in mk.debian helpers

LOG-11761
