### PR TITLE
Fix: Typo in README File

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@
 > ./scripts/mk.debian.rebuild
   * same as mk.debian plus pull new base and ignore docker build cache
 
-### Example
+### Example Command
 Build **Bullseye** image for x86 64bit:
 > PLATFORM=linux/amd64  ARCH=x86_64  VARIANT_VERSION=bullseye  ./scripts/mk.debian

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@
   * same as mk.debian plus pull new base and ignore docker build cache
 
 ### Example Command
-Build **Bullseye** image for x86 64bit:
+Build **Bullseye** image for x86 64bit arch:
 > PLATFORM=linux/amd64  ARCH=x86_64  VARIANT_VERSION=bullseye  ./scripts/mk.debian

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@
 
 ### Example
 Build **Bullseye** image for x86 64bit:
-> PLATFORM=linux/amd64  ARCH=x86_84  VARIANT_VERSION=bullseye  ./scripts/mk.debian
+> PLATFORM=linux/amd64  ARCH=x86_64  VARIANT_VERSION=bullseye  ./scripts/mk.debian


### PR DESCRIPTION
Fixing typo in README file. Will cause error if user does a copy/paste on example. 