### PR TITLE
Reinstate cross compile images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
           }
           axis {
             name 'PLATFORM'
-            values 'amd64', 'arm64'
+            values 'linux/amd64', 'linux/arm64'
           }
         }
         agent {
@@ -88,7 +88,7 @@ pipeline {
                           , variant_base: "debian"
                           , variant_version: "${VARIANT_VERSION}"
                           , version: "${RUSTC_VERSION}"
-                          , image_suffix: "base-${ARCH}-${PLATFORM}"
+                          , image_suffix: "base-${ARCH}-${PLATFORM.replaceAll('/','-')}"
                         )
 
                         buildImage(
@@ -97,7 +97,7 @@ pipeline {
                           , variant_version: "${VARIANT_VERSION}"
                           , version: "${RUSTC_VERSION}"
                           , arch: "${ARCH}"
-                          , platform: "linux/${PLATFORM}"
+                          , platform: "${PLATFORM}"
                           , dockerfile: "Dockerfile.base"
                           , image_name: image_name
                           , pull: true
@@ -133,7 +133,7 @@ pipeline {
           }
           axis {
             name 'PLATFORM'
-            values 'amd64', 'arm64'
+            values 'linux/amd64', 'linux/arm64'
           }
         }
         agent {
@@ -172,14 +172,14 @@ pipeline {
                         , variant_base: "debian"
                         , variant_version: "${VARIANT_VERSION}"
                         , version: "${RUSTC_VERSION}"
-                        , image_suffix: "${ARCH}-${PLATFORM}"
+                        , image_suffix: "${ARCH}-${PLATFORM.replaceAll('/','-')}"
                       )
                       def base_name = generateImageName(
                         name: "rust"
                         , variant_base: "debian"
                         , variant_version: "${VARIANT_VERSION}"
                         , version: "${RUSTC_VERSION}"
-                        , image_suffix: "base-${ARCH}-${PLATFORM}"
+                        , image_suffix: "base-${ARCH}-${PLATFORM.replaceAll('/','-')}"
                       )
                       // GCR image
                       buildImage(
@@ -188,7 +188,7 @@ pipeline {
                         , variant_version: "${VARIANT_VERSION}"
                         , version: "${RUSTC_VERSION}"
                         , arch: "${ARCH}"
-                        , platform: "linux/${PLATFORM}"
+                        , platform: "${PLATFORM}"
                         , dockerfile: "Dockerfile"
                         , image_name: image_name
                         , base_name: base_name
@@ -200,7 +200,7 @@ pipeline {
                         , variant_base: "rust"
                         , variant_version: "rust-${VARIANT_VERSION}"
                         , version: "${RUSTC_VERSION}"
-                        , image_suffix: "${ARCH}-${PLATFORM}"
+                        , image_suffix: "${ARCH}-${PLATFORM.replaceAll('/','-')}"
                       )
                       // Dockerhub image
                       docker.withRegistry(
@@ -213,7 +213,7 @@ pipeline {
                                 , variant_version: "${VARIANT_VERSION}"
                                 , version: "${RUSTC_VERSION}"
                                 , arch: "${ARCH}"
-                                , platform: "linux/${PLATFORM}"
+                                , platform: "${PLATFORM}"
                                 , dockerfile: "Dockerfile"
                                 , image_name: docker_name
                                 , base_name: base_name

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -334,7 +334,8 @@ def generateImageName(Map config = [:]){
 
   // If config.append_git_sha is set to append it so that the image is unique
   if (append_git_sha) {
-    return "${name}-${env.GIT_REVISION,length=16}"
+    def git_sha = env.GIT_COMMIT
+    return "${name}-${git_sha.substring(0, Math.min(git_sha.length(), 16))}"
   } else {
     return name
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,7 +116,7 @@ pipeline {
     } // End Build Rust Images stage
     // Build the images containing the cross compilers targeting actual
     // distribution platforms
-    stage('Build CROSS_COMPILER_TARGET_ARCH Specific images on top of PLATFORM's base image') {
+    stage('Build CROSS_COMPILER_TARGET_ARCH Specific images on top of PLATFORMs base image') {
       matrix {
         axes {
           axis {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -193,6 +193,7 @@ pipeline {
                         , image_name: image_name
                         , base_name: base_name
                         , pull: true
+                        , clean: false
                       )
                       def docker_name = generateImageName(
                         repo_base: "docker.io/logdna",
@@ -217,7 +218,6 @@ pipeline {
                                 , dockerfile: "Dockerfile"
                                 , image_name: docker_name
                                 , base_name: base_name
-                                , clean: false
                             )
                       }
                       try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,10 +43,12 @@ pipeline {
             name 'VARIANT_VERSION'
             values 'buster', 'bullseye'
           }
+          // Target ISA for musl cross comp toolchain and precompiled libs
           axis {
             name 'ARCH'
             values 'x86_64', 'aarch64'
           }
+          // Host architecture of the built image
           axis {
             name 'PLATFORM'
             values 'linux/amd64', 'linux/arm64'
@@ -127,10 +129,12 @@ pipeline {
             name 'VARIANT_VERSION'
             values 'buster', 'bullseye'
           }
+          // Target ISA for musl cross comp toolchain and precompiled libs
           axis {
             name 'ARCH'
             values 'x86_64', 'aarch64'
           }
+          // Host architecture of the built image
           axis {
             name 'PLATFORM'
             values 'linux/amd64', 'linux/arm64'
@@ -250,6 +254,7 @@ pipeline {
             name 'VARIANT_VERSION'
             values 'buster', 'bullseye'
           }
+          // Target ISA for musl cross comp toolchain and precompiled libs
           axis {
             name 'ARCH'
             values 'x86_64', 'aarch64'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -237,38 +237,54 @@ pipeline {
       }
     }
     stage('Create Multi-Arch Images') {
-        steps{
-            script {
-                def archs = ['x86_64', 'aarch64']
-
-                for (arch in archs) {
-                    def image_name = generateImageName(
-                        name: "rust"
-                        , variant_base: "debian"
-                        , variant_version: "${VARIANT_VERSION}"
-                        , version: "${RUSTC_VERSION}"
-                        , image_suffix: "${ARCH}"
-                    )
-                    def arm64_image_name = generateImageName(
-                        name: "rust"
-                        , variant_base: "debian"
-                        , variant_version: "${VARIANT_VERSION}"
-                        , version: "${RUSTC_VERSION}"
-                        , image_suffix: "${ARCH}-linux/arm64"
-                    )
-                    def amd64_image_name = generateImageName(
-                        name: "rust"
-                        , variant_base: "debian"
-                        , variant_version: "${VARIANT_VERSION}"
-                        , version: "${RUSTC_VERSION}"
-                        , image_suffix: "${ARCH}-linux/amd64"
-                    )
-                    sh("docker manifest create ${image_name} --amend ${arm64_image_name} --amend ${amd64_image_name}")
-                    sh("docker push ${image_name}")
-                }
-            }
+      matrix {
+        axes {
+          axis {
+            name 'RUSTC_VERSION'
+            values 'stable', 'beta'
+          }
+          axis {
+            name 'VARIANT_VERSION'
+            values 'buster', 'bullseye'
+          }
+          axis {
+            name 'ARCH'
+            values 'x86_64', 'aarch64'
+          }
         }
-     }
+        stages {
+          stage ('Create Multi Arch Manifest') {
+            steps {
+              script {
+                def image_name = generateImageName(
+                   name: "rust"
+                   , variant_base: "debian"
+                   , variant_version: "${VARIANT_VERSION}"
+                   , version: "${RUSTC_VERSION}"
+                   , image_suffix: "${ARCH}"
+                   )
+                def arm64_image_name = generateImageName(
+                   name: "rust"
+                   , variant_base: "debian"
+                   , variant_version: "${VARIANT_VERSION}"
+                   , version: "${RUSTC_VERSION}"
+                   , image_suffix: "${ARCH}-linux/arm64"
+                   )
+                def amd64_image_name = generateImageName(
+                   name: "rust"
+                   , variant_base: "debian"
+                   , variant_version: "${VARIANT_VERSION}"
+                   , version: "${RUSTC_VERSION}"
+                   , image_suffix: "${ARCH}-linux/amd64"
+                   )
+                sh("docker manifest create ${image_name} --amend ${arm64_image_name} --amend ${amd64_image_name}")
+                sh("docker push ${image_name}")
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,7 +181,7 @@ pipeline {
                         , variant_base: "debian"
                         , variant_version: "${VARIANT_VERSION}"
                         , version: "${RUSTC_VERSION}"
-                        , image_suffix: "base-${CROSS_COMPILER_TARGET_ARCH}-${PLATFORM.replaceAll('/','-')}"
+                        , image_suffix: "base-${PLATFORM.replaceAll('/','-')}"
                       )
                       // GCR image
                       buildImage(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,6 +255,12 @@ pipeline {
             values 'x86_64', 'aarch64'
           }
         }
+        agent {
+          node {
+            label 'ec2-fleet'
+            customWorkspace "docker-images-${BUILD_NUMBER}"
+          }
+        }
         stages {
           stage ('Create Multi Arch Manifest') {
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,7 +280,7 @@ pipeline {
                     , variant_version: "${VARIANT_VERSION}"
                     , version: "${RUSTC_VERSION}"
                     , image_suffix: "${CROSS_COMPILER_TARGET_ARCH}"
-                    , append_git_sha: (env.CHANGE_BRANCH  == "main" || env.BRANCH_NAME == "main" )
+                    , append_git_sha: !(env.CHANGE_BRANCH  == "main" || env.BRANCH_NAME == "main" )
                     )
                 // GCR image
                 sh("docker push ${gcr_image_name}")
@@ -300,7 +300,7 @@ pipeline {
                     , variant_version: "rust-${VARIANT_VERSION}"
                     , version: "${RUSTC_VERSION}"
                     , image_suffix: "${CROSS_COMPILER_TARGET_ARCH}"
-                    , append_git_sha: (env.CHANGE_BRANCH  == "main" || env.BRANCH_NAME == "main" )
+                    , append_git_sha: !(env.CHANGE_BRANCH  == "main" || env.BRANCH_NAME == "main" )
                     )
                 // Dockerhub image
                 docker.withRegistry('https://index.docker.io/v1/', 'dockerhub-username-password') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -263,6 +263,9 @@ pipeline {
         }
         stages {
           stage ('Create Multi Arch Manifest') {
+            when {
+                expression { return ((env.CHANGE_BRANCH  == "main" || env.BRANCH_NAME == "main" ) || env.PUBLISH_IMAGE) }
+            }
             steps {
               script {
                 def image_name = generateImageName(
@@ -310,15 +313,13 @@ pipeline {
                     , version: "${RUSTC_VERSION}"
                     , image_suffix: "${ARCH}-arm64"
                     )
-                if ((env.CHANGE_BRANCH  == "main" || env.BRANCH_NAME == "main" ) || env.PUBLISH_IMAGE) {
-                  // GCR image
-                  sh("docker manifest create ${gcr_image_name} --amend ${gcr_arm64_image_name} --amend ${gcr_amd64_image_name}")
-                  sh("docker push ${gcr_image_name}")
-                  // Dockerhub image
-                  sh("docker manifest create ${docker_image_name} --amend ${docker_arm64_image_name} --amend ${docker_amd64_image_name}")
-                  docker.withRegistry('https://index.docker.io/v1/', 'dockerhub-username-password') {
-                    sh("docker push ${docker_image_name}")
-                  }
+                // GCR image
+                sh("docker manifest create ${gcr_image_name} --amend ${gcr_arm64_image_name} --amend ${gcr_amd64_image_name}")
+                sh("docker push ${gcr_image_name}")
+                // Dockerhub image
+                sh("docker manifest create ${docker_image_name} --amend ${docker_arm64_image_name} --amend ${docker_amd64_image_name}")
+                docker.withRegistry('https://index.docker.io/v1/', 'dockerhub-username-password') {
+                  sh("docker push ${docker_image_name}")
                 }
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -222,7 +222,7 @@ pipeline {
                                 , dockerfile: "Dockerfile"
                                 , image_name: docker_name
                                 , base_name: base_name
-                                , push: (env.CHANGE_BRANCH  == "main" || env.BRANCH_NAME == "main" || env.PUBLISH_DOCKER_IMAGE)
+                                , push: (env.CHANGE_BRANCH  == "main" || env.BRANCH_NAME == "main" || params.PUBLISH_DOCKER_IMAGE == true)
                             )
                       }
                       try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -274,7 +274,7 @@ pipeline {
             }
             steps {
               script {
-                def gcr_image_name = createMultiArchImageManifest(
+                def gcr_manifest_name = createMultiArchImageManifest(
                     name: "rust"
                     , variant_base: "debian"
                     , variant_version: "${VARIANT_VERSION}"
@@ -283,7 +283,7 @@ pipeline {
                     , append_git_sha: !(env.CHANGE_BRANCH  == "main" || env.BRANCH_NAME == "main" )
                     )
                 // GCR image
-                sh("docker push ${gcr_image_name}")
+                sh("docker manifest push ${gcr_manifest_name}")
               }
             }
           }
@@ -293,7 +293,7 @@ pipeline {
             }
             steps {
               script {
-                def docker_image_name = createMultiArchImageManifest(
+                def docker_manifest_name = createMultiArchImageManifest(
                     repo_base: "docker.io/logdna",
                     , name: "build-images"
                     , variant_base: "rust"
@@ -304,7 +304,7 @@ pipeline {
                     )
                 // Dockerhub image
                 docker.withRegistry('https://index.docker.io/v1/', 'dockerhub-username-password') {
-                  sh("docker push ${docker_image_name}")
+                  sh("docker manifest push ${docker_manifest_name}")
                 }
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -288,7 +288,7 @@ pipeline {
                    )
                 if ((env.CHANGE_BRANCH  == "main" || env.BRANCH_NAME == "main" ) || env.PUBLISH_IMAGE) {
                   sh("docker manifest create ${image_name} --amend ${arm64_image_name} --amend ${amd64_image_name}")
-                  sh("docker push ${image_name}")
+                  sh("docker manifest push ${image_name}")
                 }
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -444,7 +444,7 @@ def createMultiArchImageManifest(Map config = [:]){
       , variant_base: config.variant_base
       , variant_version: config.variant_version
       , version: config.version
-      , image_suffix: "${config.image_suffix}-amd64"
+      , image_suffix: "${config.image_suffix}-linux-amd64"
       , append_git_sha: append_git_sha
       )
   def arm64_image_name = generateImageName(
@@ -453,7 +453,7 @@ def createMultiArchImageManifest(Map config = [:]){
       , variant_base: config.variant_base
       , variant_version: config.variant_version
       , version: config.version
-      , image_suffix: "${config.image_suffix}-arm64"
+      , image_suffix: "${config.image_suffix}-linux-arm64"
       , append_git_sha: append_git_sha
       )
   sh("docker manifest create ${manifest_name} --amend ${arm64_image_name} --amend ${amd64_image_name}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -268,26 +268,26 @@ pipeline {
             }
             steps {
               script {
-                def image_name = generateImageName(
+                def gcr_image_name = generateImageName(
                    name: "rust"
                    , variant_base: "debian"
                    , variant_version: "${VARIANT_VERSION}"
                    , version: "${RUSTC_VERSION}"
                    , image_suffix: "${ARCH}"
                    )
-                def arm64_image_name = generateImageName(
-                   name: "rust"
-                   , variant_base: "debian"
-                   , variant_version: "${VARIANT_VERSION}"
-                   , version: "${RUSTC_VERSION}"
-                   , image_suffix: "${ARCH}-arm64"
-                   )
-                def amd64_image_name = generateImageName(
+                def gcr_amd64_image_name = generateImageName(
                    name: "rust"
                    , variant_base: "debian"
                    , variant_version: "${VARIANT_VERSION}"
                    , version: "${RUSTC_VERSION}"
                    , image_suffix: "${ARCH}-amd64"
+                   )
+                def gcr_arm64_image_name = generateImageName(
+                   name: "rust"
+                   , variant_base: "debian"
+                   , variant_version: "${VARIANT_VERSION}"
+                   , version: "${RUSTC_VERSION}"
+                   , image_suffix: "${ARCH}-arm64"
                    )
                 def docker_image_name = generateImageName(
                     repo_base: "docker.io/logdna",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -277,14 +277,14 @@ pipeline {
                    , variant_base: "debian"
                    , variant_version: "${VARIANT_VERSION}"
                    , version: "${RUSTC_VERSION}"
-                   , image_suffix: "${ARCH}-linux/arm64"
+                   , image_suffix: "${ARCH}-arm64"
                    )
                 def amd64_image_name = generateImageName(
                    name: "rust"
                    , variant_base: "debian"
                    , variant_version: "${VARIANT_VERSION}"
                    , version: "${RUSTC_VERSION}"
-                   , image_suffix: "${ARCH}-linux/amd64"
+                   , image_suffix: "${ARCH}-amd64"
                    )
                 if ((env.CHANGE_BRANCH  == "main" || env.BRANCH_NAME == "main" ) || env.PUBLISH_IMAGE) {
                   sh("docker manifest create ${image_name} --amend ${arm64_image_name} --amend ${amd64_image_name}")

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ The CI job for this repo will generate tooling images with cross compilers
 targetting aarch64 and x86_64 for both linux/amd64 and linux/arm64
 platforms.
 
+Images are pushed by default by jobs on the main branch. Images on other
+branches can be pushed by setting the PUBLISH_GCR_IMAGE and/or
+PUBLISH_DOCKER_IMAGE params on the Jenkins build job
+
 ### Image Tagging
 
 On all branches the image tags are appended with the git sha of the current

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Docker images containing build tooling
 
+## CI Generated Images
+The CI job for this repo will generate tooling images with cross compilers
+targetting aarch64 and x86_64 for both linux/amd64 and linux/arm64
+platforms.
+
+### Image Tagging
+
+On all branches the image tags are appended with the git sha of the current
+revision. On main an additional tag without the trailing sha is also pushed
+
 ## Helper scripts
 >  ./scripts/mk.debian
   * build local debian image

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ revision. On main an additional tag without the trailing sha is also pushed
 >  ./scripts/mk.debian
   * build local debian image
   * default variant: VARIANT_VERSION=**Buster**
-  * default platform: PLATFORM=**linux/arm64**
-  * default architecture:  ARCH=**aarch64**
+  * default platform: host arch
+  * default cross compiler target architecture: aarch64 and x86_64
 > ./scripts/mk.debian.rebuild
   * same as mk.debian plus pull new base and ignore docker build cache
 

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -1,5 +1,5 @@
-ARG ARCH=x86_64
-ARG BASE_IMAGE=logdna/build-images/rust-buster-1-stable-base-${ARCH}
+ARG CROSS_COMPILER_TARGET_ARCH=x86_64
+ARG BASE_IMAGE=logdna/build-images/rust-buster-1-stable-base-${CROSS_COMPILER_TARGET_ARCH}
 FROM ${BASE_IMAGE}
 
 ARG SCCACHE_BUCKET
@@ -10,12 +10,13 @@ ARG SCCACHE_SERVER_PORT=4226
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY
 
-ARG ARCH=x86_64
+ARG CROSS_COMPILER_TARGET_ARCH=x86_64
 
-RUN rustup target add ${ARCH}-unknown-linux-musl && \
+RUN rustup target add ${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl && \
+    rustup target add ${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-gnu  && \
     chmod -R a+rw $RUSTUP_HOME $CARGO_HOME
 
-## Install a musl cross compiler for ${ARCH} using musl-cross-make
+## Install a musl cross compiler for ${CROSS_COMPILER_TARGET_ARCH} using musl-cross-make
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     if [ -z "$SCCACHE_BUCKET" ]; then unset CC_WRAPPER; fi; \
     if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
@@ -31,16 +32,13 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
         DL_CMD='curl --retry 3 -sSfL -C - -o' \
         LINUX_HEADERS_SITE=https://ci-mirrors.rust-lang.org/rustc/sabotage-linux-tarballs \
         OUTPUT=/usr/local/ \
-        TARGET=${ARCH}-linux-musl && \
+        TARGET=${CROSS_COMPILER_TARGET_ARCH}-linux-musl && \
     sccache --show-stats && \
     rm -rf /tmp/musl-cross
 
-RUN echo "[target.${ARCH}-unknown-linux-musl]" >> $CARGO_HOME/config.toml && \
-    echo "linker = \"${ARCH}-linux-musl-gcc\"" >> $CARGO_HOME/config.toml
-
-## Set up cargo env vars for cross compiling
-ENV CC_${ARCH}_unknown_linux_musl=${ARCH}-linux-musl-gcc \
-    CXX_${ARCH}_unknown_linux_musl=${ARCH}-linux-musl-g++
+## Set up default cargo env vars for cross compiling
+ENV CC_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_musl=${CROSS_COMPILER_TARGET_ARCH}-linux-musl-gcc \
+    CXX_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_musl=${CROSS_COMPILER_TARGET_ARCH}-linux-musl-g++
 
 ## Install static Zlib
 ARG ZLIB_VERSION=1.2.11
@@ -51,7 +49,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     cd /tmp && \
     curl -fLO "http://zlib.net/zlib-$ZLIB_VERSION.tar.gz" && \
     tar xzf "zlib-$ZLIB_VERSION.tar.gz" && cd "zlib-$ZLIB_VERSION" && \
-    CC="$CC_WRAPPER ${ARCH}-linux-musl-gcc" ./configure --static --prefix=/usr/local/musl && \
+    CC="$CC_WRAPPER ${CROSS_COMPILER_TARGET_ARCH}-linux-musl-gcc" ./configure --static --prefix=/usr/local/musl && \
     make -j$(nproc) && make install && \
     sccache --show-stats && \
     rm -r /tmp/*
@@ -71,13 +69,13 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     cd rocksdb && \
     git checkout v6.22.1 && \
     PORTABLE=1 CCFLAGS=-fPIC CXXFLAGS=-fPIC \
-    CC="$CC_WRAPPER ${ARCH}-linux-musl-gcc" CXX="$CC_WRAPPER ${ARCH}-linux-musl-g++" \
+    CC="$CC_WRAPPER ${CROSS_COMPILER_TARGET_ARCH}-linux-musl-gcc" CXX="$CC_WRAPPER ${CROSS_COMPILER_TARGET_ARCH}-linux-musl-g++" \
     make -j$(nproc) static_lib && \
-    mkdir -p /usr/local/rocksdb/${ARCH}-linux-musl/lib && \
-    mkdir /usr/local/rocksdb/${ARCH}-linux-musl/include && \
-    cp librocksdb.a* /usr/local/rocksdb/${ARCH}-linux-musl/lib && \
-    cp -r include /usr/local/rocksdb/${ARCH}-linux-musl/ && \
-    cp -r include/* /usr/include/${ARCH}-linux-musl/ && \
+    mkdir -p /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib && \
+    mkdir /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/include && \
+    cp librocksdb.a* /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib && \
+    cp -r include /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/ && \
+    cp -r include/* /usr/include/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/ && \
     sccache --show-stats && \
     rm -R /tmp/rocksdb/
 

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -38,7 +38,9 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
 
 ## Set up default cargo env vars for cross compiling
 ENV CC_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_musl=${CROSS_COMPILER_TARGET_ARCH}-linux-musl-gcc \
-    CXX_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_musl=${CROSS_COMPILER_TARGET_ARCH}-linux-musl-g++
+    CXX_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_musl=${CROSS_COMPILER_TARGET_ARCH}-linux-musl-g++ \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc
 
 ## Install static Zlib
 ARG ZLIB_VERSION=1.2.11

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -69,24 +69,10 @@ RUN cd /tmp \
 ENV RUSTC_WRAPPER="/usr/local/bin/sccache"
 ENV CC_WRAPPER="/usr/local/bin/sccache"
 
-RUN cd /tmp \
-    && ARCH=$(uname -m) \
-    && curl -L https://api.github.com/repos/rustsec/cargo-audit/releases/latest \
-    | grep "browser_download_url" \
-    | grep -E "cargo-audit-${ARCH}-unknown-linux-musl-v.*.tgz\"$" \
-    | awk '{$1=$1;print}' \
-    | cut -f2 -d" " \
-    | xargs curl -LO \
-    && mkdir -p /tmp/cargo-audit \
-    && tar -C /tmp/cargo-audit --strip-components=1 -xf /tmp/cargo-audit-${ARCH}-unknown-linux-musl-v*.tgz \
-    && mv /tmp/cargo-audit/cargo-audit /usr/local/bin/cargo-audit \
-    && chmod +x /usr/local/bin/cargo-audit \
-    && rm -rf /tmp/*
-
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     if [ -z "$SCCACHE_BUCKET" ]; then unset CC_WRAPPER; fi; \
     if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
-    cargo install flamegraph && \
+    cargo install flamegraph cargo-audit && \
     cargo install --version 0.6.3 cargo-cache && \
     cargo cache -a && \
     sccache --show-stats

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -47,14 +47,14 @@ ARG VERSION="stable"
 
 # Install rust
 ENV CARGO_HOME=/opt/rust/cargo
-RUN curl https://sh.rustup.rs -sSf | \
+RUN curl -L https://sh.rustup.rs -sSf | \
     sh -s -- -y --default-toolchain $VERSION --component clippy rustfmt --profile minimal --no-modify-path && \
     chmod -R a+rw $RUSTUP_HOME $CARGO_HOME
 
 # Install sccache
 RUN cd /tmp \
     && ARCH=$(uname -m) \
-    && curl https://api.github.com/repos/mozilla/sccache/releases/latest \
+    && curl -L https://api.github.com/repos/mozilla/sccache/releases/latest \
     | grep "browser_download_url" \
     | grep -E "sccache-v.*${ARCH}-unknown-linux-musl.tar.gz\"$" \
     | awk '{$1=$1;print}' \
@@ -69,10 +69,24 @@ RUN cd /tmp \
 ENV RUSTC_WRAPPER="/usr/local/bin/sccache"
 ENV CC_WRAPPER="/usr/local/bin/sccache"
 
+RUN cd /tmp \
+    && ARCH=$(uname -m) \
+    && curl -L https://api.github.com/repos/rustsec/cargo-audit/releases/latest \
+    | grep "browser_download_url" \
+    | grep -E "cargo-audit-${ARCH}-unknown-linux-gnu-v.*.tgz\"$" \
+    | awk '{$1=$1;print}' \
+    | cut -f2 -d" " \
+    | xargs curl -LO \
+    && mkdir -p /tmp/cargo-audit \
+    && tar -C /tmp/cargo-audit --strip-components=1 -xf /tmp/cargo-audit-${ARCH}-unknown-linux-gnu-v*.tgz \
+    && mv /tmp/cargo-audit/cargo-audit /usr/local/bin/cargo-audit \
+    && chmod +x /usr/local/bin/cargo-audit \
+    && rm -rf /tmp/*
+
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     if [ -z "$SCCACHE_BUCKET" ]; then unset CC_WRAPPER; fi; \
     if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
-    cargo install cargo-audit flamegraph && \
+    cargo install flamegraph && \
     cargo install --version 0.6.3 cargo-cache && \
     cargo cache -a && \
     sccache --show-stats

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -20,7 +20,7 @@ COPY .curlrc /root
 
 RUN env
 
-RUN DEPS='build-essential binutils ca-certificates curl file gcc g++ libtool m4 libc6-dev make xz-utils locales libexpat1-dev gettext libz-dev libssl-dev autoconf pkg-config bzip2 libsystemd-dev systemd lsof procps git cmake automake hunspell-en-gb hunspell-tools linux-perf clang-12 llvm-12 lldb texinfo procps' \
+RUN DEPS='build-essential binutils ca-certificates curl file gcc g++ libtool m4 libc6-dev make xz-utils locales libexpat1-dev gettext libz-dev libssl-dev autoconf pkg-config bzip2 libsystemd-dev systemd lsof procps git cmake automake hunspell-en-gb hunspell-tools linux-perf clang-12 llvm-12 lldb-12 texinfo procps' \
   && apt-get update \
   && apt-get install -y --no-install-recommends software-properties-common \
   && apt-key add /llvm-snapshot.gpg.key \
@@ -73,12 +73,12 @@ RUN cd /tmp \
     && ARCH=$(uname -m) \
     && curl -L https://api.github.com/repos/rustsec/cargo-audit/releases/latest \
     | grep "browser_download_url" \
-    | grep -E "cargo-audit-${ARCH}-unknown-linux-gnu-v.*.tgz\"$" \
+    | grep -E "cargo-audit-${ARCH}-unknown-linux-musl-v.*.tgz\"$" \
     | awk '{$1=$1;print}' \
     | cut -f2 -d" " \
     | xargs curl -LO \
     && mkdir -p /tmp/cargo-audit \
-    && tar -C /tmp/cargo-audit --strip-components=1 -xf /tmp/cargo-audit-${ARCH}-unknown-linux-gnu-v*.tgz \
+    && tar -C /tmp/cargo-audit --strip-components=1 -xf /tmp/cargo-audit-${ARCH}-unknown-linux-musl-v*.tgz \
     && mv /tmp/cargo-audit/cargo-audit /usr/local/bin/cargo-audit \
     && chmod +x /usr/local/bin/cargo-audit \
     && rm -rf /tmp/*

--- a/scripts/mk.debian
+++ b/scripts/mk.debian
@@ -10,16 +10,18 @@ export DOCKER_BUILDKIT=1
 #   linux/arm64       aarch64
 declare -A platforms=( ["x86_64"]="linux/amd64" ["aarch64"]="linux/arm64")
 
+CROSS_COMPILER_TARGET_ARCHS="x86_64 aarch64"
+
 # Default to the host ARCH
 HOST_ARCH=$(uname -m)
 # special case handling for M1s
 if [[ $HOST_ARCH == 'arm64' ]]; then
-    ARCH=${ARCH:-'aarch64'}
+    HOST_ARCH=${HOST_ARCH:-'aarch64'}
 else
-    ARCH=${ARCH:-$HOST_ARCH}
+    HOST_ARCH=${HOST_ARCH:-$HOST_ARCH}
 fi
 
-PLATFORM=${PLATFORM:-${platforms[$ARCH]}}
+PLATFORM=${PLATFORM:-${platforms[$HOST_ARCH]}}
 VARIANT_VERSION=${VARIANT_VERSION:-buster}
 time (
 echo
@@ -34,25 +36,27 @@ docker build --platform "$PLATFORM" \
              --build-arg "SCCACHE_RECACHE=${SCCACHE_RECACHE}" \
              --build-arg "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
              --build-arg "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
-             --build-arg "ARCH=${ARCH}" \
              --build-arg "VARIANT_VERSION=${VARIANT_VERSION}" \
-             -t "docker.io/logdna/build-images:rust-${VARIANT_VERSION}-1-stable-base-${ARCH}" \
+             -t "docker.io/logdna/build-images:rust-${VARIANT_VERSION}-1-stable-base--${HOST_ARCH}" \
              -f rust/debian/Dockerfile.base ${PULL_OPTS} rust/debian
 echo
 echo ===================================================
 echo
-docker build --platform "$PLATFORM" \
-             --progress=plain \
-             --build-arg "SCCACHE_BUCKET=${SCCACHE_BUCKET}" \
-             --build-arg "SCCACHE_REGION=${SCCACHE_REGION}" \
-             --build-arg "SCCACHE_ENDPOINT=${SCCACHE_ENDPOINT}" \
-             --build-arg "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
-             --build-arg "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
-             --build-arg "ARCH=${ARCH}" \
-             --build-arg "BASE_IMAGE=docker.io/logdna/build-images:rust-${VARIANT_VERSION}-1-stable-base-${ARCH}" \
-             -t "docker.io/logdna/build-images:rust-${VARIANT_VERSION}-1-stable-${ARCH}" \
-             -f rust/debian/Dockerfile rust/debian
-)
+for CROSS_COMPILER_TARGET_ARCH in $CROSS_COMPILER_TARGET_ARCHS
+do
+    docker build --platform "$PLATFORM" \
+                --progress=plain \
+                --build-arg "SCCACHE_BUCKET=${SCCACHE_BUCKET}" \
+                --build-arg "SCCACHE_REGION=${SCCACHE_REGION}" \
+                --build-arg "SCCACHE_ENDPOINT=${SCCACHE_ENDPOINT}" \
+                --build-arg "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
+                --build-arg "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
+                --build-arg "CROSS_COMPILER_TARGET_ARCH=${CROSS_COMPILER_TARGET_ARCH}" \
+                --build-arg "BASE_IMAGE=docker.io/logdna/build-images:rust-${VARIANT_VERSION}-1-stable-base-${HOST_ARCH}" \
+                -t "docker.io/logdna/build-images:rust-${VARIANT_VERSION}-1-stable-${CROSS_COMPILER_TARGET_ARCH}" \
+                -f rust/debian/Dockerfile rust/debian
+done
 echo
 echo @@@@@@  SUCCESS  @@@@@@
 echo
+)

--- a/scripts/mk.debian
+++ b/scripts/mk.debian
@@ -37,7 +37,7 @@ docker build --platform "$PLATFORM" \
              --build-arg "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
              --build-arg "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
              --build-arg "VARIANT_VERSION=${VARIANT_VERSION}" \
-             -t "docker.io/logdna/build-images:rust-${VARIANT_VERSION}-1-stable-base--${HOST_ARCH}" \
+             -t "docker.io/logdna/build-images:rust-${VARIANT_VERSION}-1-stable-base-${HOST_ARCH}" \
              -f rust/debian/Dockerfile.base ${PULL_OPTS} rust/debian
 echo
 echo ===================================================


### PR DESCRIPTION
This reinstates the aarch64-musl static toolchain image for linux/amd64 hosts and the x86_64-musl static toolchain image for linux/arm64 hosts, then uses a manifest to create multi-arch tags.

It also updates the unfortunate ARCH naming from the Jenkinsfile which became confusing when we added linux/arm64 platform support to the images.

And finally it adds a git-sha to the generated image names so that we can pin to a particular image