### PR TITLE
ci: change jenkins worker label definition

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,7 @@ pipeline {
                 # initialize qemu
                 test -z /proc/sys/fs/binfmt_misc/ && \
                 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || \
+                ls /proc/sys/fs/binfmt_misc/ && \
                 echo "Qemu binfmts already registered"
               """
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,9 @@ pipeline {
                 free -h && df -h
                 cat /proc/cpuinfo
                 # initialize qemu
-                docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+                test -z /proc/sys/fs/binfmt_misc/ && \
+                docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || \
+                echo "Qemu binfmts already registered"
               """
             }
           }
@@ -183,7 +185,9 @@ pipeline {
                 free -h && df -h
                 cat /proc/cpuinfo
                 # initialize qemu
-                docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+                test -z /proc/sys/fs/binfmt_misc/ && \
+                docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || \
+                echo "Qemu binfmts already registered"
               """
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,12 @@
 library 'magic-butler-catalogue'
 
 pipeline {
-  agent none
+  agent {
+    node {
+      label 'ec2-fleet'
+      customWorkspace "docker-images-${BUILD_NUMBER}"
+    }
+  }
 
   options {
     timestamps()
@@ -70,12 +75,6 @@ pipeline {
                     values 'linux/amd64'
                 }
             }
-        }
-        agent {
-          node {
-            label 'ec2-fleet'
-            customWorkspace "docker-images-${BUILD_NUMBER}"
-          }
         }
         stages {
           stage('Initilize qemu') {
@@ -176,12 +175,6 @@ pipeline {
                     values 'linux/amd64'
                 }
             }
-        }
-        agent {
-          node {
-            label 'ec2-fleet'
-            customWorkspace "docker-images-${BUILD_NUMBER}"
-          }
         }
         stages {
           stage('Initilize qemu') {

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -18,8 +18,6 @@ ENV PATH="${CARGO_HOME}/bin:${PATH}"
 COPY llvm-snapshot.gpg.key /llvm-snapshot.gpg.key
 COPY .curlrc /root
 
-RUN env
-
 RUN DEPS='build-essential binutils ca-certificates curl file gcc g++ libtool m4 libc6-dev make xz-utils locales libexpat1-dev gettext libz-dev libssl-dev autoconf pkg-config bzip2 libsystemd-dev systemd lsof procps git cmake automake hunspell-en-gb hunspell-tools linux-perf clang-12 llvm-12 lldb texinfo procps' \
   && apt-get update \
   && apt-get install -y --no-install-recommends software-properties-common \


### PR DESCRIPTION
- since all stages are using the same jenkins worker definition, define
  it at the job level, instead of per-stage.
  - this will make maintenance easier
  - it may potentially also make the job more resilient if the
    controller is unavailable between stages

ref: REL-833
