### PR TITLE
Fixup unsha'd manifests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,8 +192,8 @@ pipeline {
                             , variant_version: "${VARIANT_VERSION}"
                             , version: "${RUSTC_VERSION}"
                             , image_suffix: "${CROSS_COMPILER_TARGET_ARCH}-${PLATFORM.replaceAll('/','-')}"
-                          )
-                        )
+                            , append_git_sha: false
+                          ))
                       }
                       buildImage(
                         name: "rust"
@@ -227,8 +227,8 @@ pipeline {
                             , variant_version: "rust-${VARIANT_VERSION}"
                             , version: "${RUSTC_VERSION}"
                             , image_suffix: "${CROSS_COMPILER_TARGET_ARCH}-${PLATFORM.replaceAll('/','-')}"
-                          )
-                        )
+                            , append_git_sha: false
+                          ))
                       }
 
                       // Dockerhub image
@@ -405,6 +405,7 @@ def generateImageName(Map config = [:]){
                 , variant_version: config.variant_version
                 , version: config.version
                 , image_suffix: config.get("image_suffix", null)
+                , append_git_sha: append_git_sha
             )
 
   return "${repo_base}/${config.name}:${tag}"

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -39,6 +39,8 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
 ## Set up default cargo env vars for cross compiling
 ENV CC_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_musl=${CROSS_COMPILER_TARGET_ARCH}-linux-musl-gcc \
     CXX_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_musl=${CROSS_COMPILER_TARGET_ARCH}-linux-musl-g++ \
+    CC_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_gnu=gcc \
+    CXX_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_gnu=g++ \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
     CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc
 


### PR DESCRIPTION
This PR ensures that the platform specific manifests used by the multi-platform manifests for the main, sha-less tags are correctly updated. rather than it just reusing older manifests...