### PR TITLE
Add multiarch manifest for base image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
         }
         agent {
           node {
-            label 'ec2-fleet'
+            label 'rust-x86_64'
             customWorkspace "docker-images-${BUILD_NUMBER}"
           }
         }
@@ -130,7 +130,7 @@ pipeline {
         }
         agent {
           node {
-            label 'ec2-fleet'
+            label 'rust-x86_64'
             customWorkspace "docker-images-${BUILD_NUMBER}"
           }
         }
@@ -177,7 +177,7 @@ pipeline {
         }
         agent {
           node {
-            label 'ec2-fleet'
+            label 'rust-x86_64'
             customWorkspace "docker-images-${BUILD_NUMBER}"
           }
         }
@@ -325,7 +325,7 @@ pipeline {
         }
         agent {
           node {
-            label 'ec2-fleet'
+            label 'rust-x86_64'
             customWorkspace "docker-images-${BUILD_NUMBER}"
           }
         }


### PR DESCRIPTION
This adds multiarch support for the base image, which allows for much simpler cross compilation in the final images