### PR TITLE
Log 12405 replace musl gcc with clang

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
         }
         agent {
           node {
-            label 'rust-arm64'
+            label 'rust-x86_64'
             customWorkspace "docker-images-${BUILD_NUMBER}"
           }
         }
@@ -130,7 +130,7 @@ pipeline {
         }
         agent {
           node {
-            label 'rust-arm64'
+            label 'rust-x86_64'
             customWorkspace "docker-images-${BUILD_NUMBER}"
           }
         }
@@ -177,7 +177,7 @@ pipeline {
         }
         agent {
           node {
-            label 'rust-arm64'
+            label 'rust-x86_64'
             customWorkspace "docker-images-${BUILD_NUMBER}"
           }
         }
@@ -325,7 +325,7 @@ pipeline {
         }
         agent {
           node {
-            label 'rust-arm64'
+            label 'rust-x86_64'
             customWorkspace "docker-images-${BUILD_NUMBER}"
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
         }
         agent {
           node {
-            label 'rust-x86_64'
+            label 'rust-arm64'
             customWorkspace "docker-images-${BUILD_NUMBER}"
           }
         }
@@ -130,7 +130,7 @@ pipeline {
         }
         agent {
           node {
-            label 'rust-x86_64'
+            label 'rust-arm64'
             customWorkspace "docker-images-${BUILD_NUMBER}"
           }
         }
@@ -177,7 +177,7 @@ pipeline {
         }
         agent {
           node {
-            label 'rust-x86_64'
+            label 'rust-arm64'
             customWorkspace "docker-images-${BUILD_NUMBER}"
           }
         }
@@ -325,7 +325,7 @@ pipeline {
         }
         agent {
           node {
-            label 'rust-x86_64'
+            label 'rust-arm64'
             customWorkspace "docker-images-${BUILD_NUMBER}"
           }
         }

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -217,7 +217,6 @@ ARG SCCACHE_SERVER_PORT=4226
 ARG CROSS_COMPILER_TARGET_ARCH
 ENV LLVM_SYSROOT="/sysroot/${CROSS_COMPILER_TARGET_ARCH}-musl"
 ENV MUSL_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl"
-ENV GNU_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-gnu"
 
 # Copy files around to ensure changes are compatible with agent 3.3 and 3.4
 RUN mkdir -p /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/include && \
@@ -225,7 +224,6 @@ RUN mkdir -p /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/include
     cp $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib/librocksdb.a* /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib && \
     cp -r $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/rocksdb/ /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/include/ && \
     cp -r $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/rocksdb/ /usr/include/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/ && \
-    cp -r $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/* /usr/local/include/ && \
     cp -r $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl /usr/local/${CROSS_COMPILER_TARGET_ARCH}-linux-musl && \
     cp -r $LLVM_SYSROOT/usr/lib/* /usr/local/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib/ && \
     ln -s /usr/lib/llvm-${LLVM_MAJOR_VERSION}/bin/llvm-strip /usr/local/bin/${CROSS_COMPILER_TARGET_ARCH}-linux-gnu-strip && \

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -22,7 +22,7 @@ RUN rustup target add "${!TARGETARCH}-unknown-linux-musl"  && \
 
 RUN dpkg --add-architecture ${TARGETARCH} && \
     dpkg --add-architecture ${!CROSS_COMPILER_TARGET_ARCH} && \
-    apt-get update -y && apt-get install --no-install-recommends -y musl-dev:${TARGETARCH}
+    apt-get -q update -y && apt-get -q install --no-install-recommends -y musl-dev:${TARGETARCH}
 
 ENV CC_aarch64_unknown_linux_musl=clang
 ENV CFLAGS_aarch64_unknown_linux_musl="-isystem /usr/include/aarch64-linux-musl"
@@ -34,13 +34,13 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     if [ -z "$SCCACHE_BUCKET" ]; then unset RUSTC_WRAPPER; fi; \
     if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
     mkdir -p /out/tools && \
-    cargo install --git https://github.com/flamegraph-rs/flamegraph \
+    cargo install -q --git https://github.com/flamegraph-rs/flamegraph \
         --tag v0.5.1 --locked --root /out/tools \
         --target=${!TARGETARCH}-unknown-linux-musl && \
-    cargo install cargo-cache --version 0.8.2  --locked --root /out/tools \
+    cargo install -q cargo-cache --version 0.8.2  --locked --root /out/tools \
         --no-default-features --features ci-autoclean,vendored-libgit \
         --target=${!TARGETARCH}-unknown-linux-musl && \
-    cargo install cargo-audit --version 0.16.0  --locked --root /out/tools \
+    cargo install -q cargo-audit --version 0.16.0  --locked --root /out/tools \
         --no-default-features --features vendored-openssl,vendored-libgit2 \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     sccache --show-stats
@@ -58,7 +58,7 @@ RUN mkdir -p $LLVM_SYSROOT
 RUN cd /tmp && \
     curl --retry 5 -sSfL -O "https://github.com/sabotage-linux/kernel-headers/archive/v$LINUX_HEADER_VERSION.tar.gz" && \
     tar xf v$LINUX_HEADER_VERSION.tar.gz && cd kernel-headers-$LINUX_HEADER_VERSION && \
-    make -j $(nproc) ARCH=${CROSS_COMPILER_TARGET_ARCH} prefix=$LLVM_SYSROOT/usr/ install && \
+    make --silent -j $(nproc) ARCH=${CROSS_COMPILER_TARGET_ARCH} prefix=$LLVM_SYSROOT/usr/ install && \
     cd / && rm -r /tmp/*
 
 # Download and untar musl
@@ -75,11 +75,11 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     ./configure --prefix=$LLVM_SYSROOT/usr/$MUSL_TRIPLE \
                 --syslibdir=$LLVM_SYSROOT/usr/lib \
                 --build=${!BUILDARCH} \
-                --target=$MUSL_TRIPLE && \
-    make -j $(nproc) install-headers
+                --target=$MUSL_TRIPLE 2>&1 >/dev/null && \
+    make --silent -j $(nproc) install-headers
 
 # Configure cmake for building llvm headers, compiler-rt and builtins
-ENV CMAKE_COMMAND="cmake --parallel=$(nproc)"
+ENV CMAKE_COMMAND="cmake -q --parallel=$(nproc) --log-level=WARNING -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_INSTALL_MESSAGE=NEVER"
 ENV CMAKE_HOST_ARGS="-DCMAKE_INSTALL_PREFIX=${LLVM_SYSROOT}/usr -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld"
 ENV CMAKE_HOST="$CMAKE_COMMAND $CMAKE_HOST_ARGS"
 ENV CMAKE_TARGET=${CROSS_COMPILER_TARGET_ARCH}-linux-musl
@@ -95,7 +95,7 @@ ENV CMAKE_CROSS_ARGS="${CMAKE_PROGRAMS} ${CMAKE_HOST_ARGS} \
 ENV CMAKE_SHARED_FLAGS="--gcc-toolchain=${LLVM_SYSROOT}/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl \
                         -fuse-ld=lld -nostdinc -nodefaultlibs -nostdlib \
                         -isystem ${LLVM_SYSROOT}/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/ \
-                        -isystem ${LLVM_SYSROOT}/usr/include/"
+                        -isystem ${LLVM_SYSROOT}/usr/include/ -Wno-unused-command-line-argument"
 ENV CMAKE_C_FLAGS="${CMAKE_SHARED_FLAGS} -B${LLVM_SYSROOT}/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib/"
 ENV CMAKE_CXX_FLAGS="-nostdinc++ ${CMAKE_SHARED_FLAGS} --stdlib=libc++ --rtlib=compiler-rt"
 ENV CMAKE_CROSS="$CMAKE_COMMAND $CMAKE_CROSS_ARGS"
@@ -114,30 +114,30 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     $CMAKE_HOST -DLLVM_ENABLE_DOXYGEN=OFF .. && \
     cd $REPOS/clang && mkdir build && cd build && \
     $CMAKE_HOST $CMAKE_LAUNCHERS -DCMAKE_MODULE_PATH="$REPOS/llvm/build/cmake/modules/CMakeFiles;$REPOS/llvm/build/lib/cmake/llvm/" -DLLVM_ENABLE_LIBCXX:BOOL=ON -DLLVM_DIR="$REPOS/llvm" .. && \
-    make -j $(nproc) install-clang-resource-headers && \
+    make --silent -j $(nproc) install-clang-resource-headers && \
     # Generate and install sysroot libc++ headers \
     cd $REPOS/libcxx && mkdir build && cd build && \
     $CMAKE_CROSS $CMAKE_LAUNCHERS -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" -DCMAKE_C_IMPLICIT_LINK_DIRECTORIES= -DCMAKE_CXX_IMPLICIT_LINK_DIRECTORIES= -DLIBCXX_LINK_FLAGS=-fuse-ld=lld -DLIBCXX_GCC_TOOLCHAIN=$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl -DLIBCXX_HAS_MUSL_LIBC=1 -DLIBCXX_HAS_GCC_S_LIB=0 -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$REPOS/libcxxabi/include" -DLIBCXX_CXX_ABI_LIBRARY_PATH="$REPOS/libcxxabi/build/lib" -DLLVM_PATH="$REPOS/llvm" .. && \
-    make -j $(nproc) cxx_abi_headers generate-cxx-headers install-cxx-headers && \
+    make --silent -j $(nproc) cxx_abi_headers generate-cxx-headers install-cxx-headers && \
     # Build and install sysroot compiler-rt \
     cd $REPOS/compiler-rt && mkdir build && cd build && \
     $CMAKE_CROSS $CMAKE_LAUNCHERS -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS}" -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" -DCMAKE_C_IMPLICIT_LINK_DIRECTORIES= -DCMAKE_CXX_IMPLICIT_LINK_DIRECTORIES= -DCOMPILER_RT_BUILD_BUILTINS=ON -DCOMPILER_RT_BUILD_LIBFUZZER=OFF -DCOMPILER_RT_BUILD_MEMPROF=OFF -DCOMPILER_RT_BUILD_PROFILE=OFF -DCOMPILER_RT_BUILD_SANITIZERS=OFF -DCOMPILER_RT_BUILD_XRAY=OFF -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON -DLLVM_PATH="$REPOS/llvm" .. && \
-    make -j $(nproc) install-builtins && \
+    make --silent -j $(nproc) install-builtins && \
     # Finish up musl libc build and install \
     cd /tmp/musl-$MUSL_VERSION && \
-    make -j $(nproc) install && \
+    make --silent -j $(nproc) install && \
     # Build libunwind \
     cd $REPOS/libunwind && mkdir build && cd build && \
     $CMAKE_CROSS $CMAKE_LAUNCHERS -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" -DLIBUNWIND_LINK_FLAGS=-fuse-ld=lld -DCMAKE_LLVM_SYSROOT=${LLVM_SYSROOT} -DLIBUNWIND_GCC_TOOLCHAIN=$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl -DLIBUNWIND_ENABLE_SHARED=0 -DLLVM_PATH="$REPOS/llvm" .. && \
-    make -j $(nproc) && \
+    make --silent -j $(nproc) && \
     # Build and install libcxxabi \
     cd $REPOS/libcxxabi/ && mkdir build && cd build && \
     $CMAKE_CROSS $CMAKE_LAUNCHERS -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" -DLIBCXXABI_HAS_CXA_THREAD_ATEXIT_IMPL=NO -DLIBCXXABI_LINK_FLAGS=-fuse-ld=lld -DLIBCXXABI_GCC_TOOLCHAIN=$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl -DCMAKE_SHARED_LINKER_FLAGS="-L$REPOS/libunwind/build/lib" -DLIBCXXABI_USE_LLVM_UNWINDER=1 -DLIBCXXABI_LIBUNWIND_PATH="$REPOS/libunwind" -DLIBCXXABI_LIBCXX_INCLUDES="$REPOS/libcxx/build/include/c++/v1/" -DLLVM_PATH="$REPOS/llvm" .. && \
-    make -j $(nproc) cxxabi_static && \
-    make -j $(nproc) install && \
+    make --silent -j $(nproc) cxxabi_static && \
+    make --silent -j $(nproc) install && \
     # Build and install libc++ \
     cd $REPOS/libcxx/build && \
-    make -j $(nproc) install && \
+    make --silent -j $(nproc) install && \
     cd / && rm -r /tmp/*
 
 
@@ -177,12 +177,12 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     echo 'COMMON_CONFIG="CC=$(CC_WRAPPER) $(CC)"' >> config.mak && \
     echo 'COMMON_CONFIG += "CXX=$(CC_WRAPPER) $(CXX)"' >> config.mak && \
     echo 'COMMON_CONFIG += "STAGE_CC_WRAPPER=$(CC_WRAPPER)"' >> config.mak && \
-    make install "-j$(nproc)" \
+    make --silent install "-j$(nproc)" \
         CC_WRAPPER=$CC_WRAPPER \
         DL_CMD='curl --retry 3 -sSfL -C - -o' \
         LINUX_HEADERS_SITE=https://ci-mirrors.rust-lang.org/rustc/sabotage-linux-tarballs \
         OUTPUT=/usr/local/ \
-        TARGET=${CROSS_COMPILER_TARGET_ARCH}-linux-musl && \
+        TARGET=${CROSS_COMPILER_TARGET_ARCH}-linux-musl > build.log && \
     sccache --show-stats && \
     rm -rf /tmp/musl-cross
 

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir -p $LLVM_SYSROOT
 RUN cd /tmp && \
     curl --retry 5 -sSfL -O "https://github.com/sabotage-linux/kernel-headers/archive/v$LINUX_HEADER_VERSION.tar.gz" && \
     tar xf v$LINUX_HEADER_VERSION.tar.gz && cd kernel-headers-$LINUX_HEADER_VERSION && \
-    make ARCH=${CROSS_COMPILER_TARGET_ARCH} prefix=$LLVM_SYSROOT/usr/ install && \
+    make -j $(nproc) ARCH=${CROSS_COMPILER_TARGET_ARCH} prefix=$LLVM_SYSROOT/usr/ install && \
     cd / && rm -r /tmp/*
 
 # Download and untar musl
@@ -76,7 +76,70 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
                 --syslibdir=$LLVM_SYSROOT/usr/lib \
                 --build=${!BUILDARCH} \
                 --target=$MUSL_TRIPLE && \
-    make install-headers
+    make -j $(nproc) install-headers
+
+# Configure cmake for building llvm headers, compiler-rt and builtins
+ENV CMAKE_COMMAND="cmake --parallel=$(nproc)"
+ENV CMAKE_HOST_ARGS="-DCMAKE_INSTALL_PREFIX=${LLVM_SYSROOT}/usr -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld"
+ENV CMAKE_HOST="$CMAKE_COMMAND $CMAKE_HOST_ARGS"
+ENV CMAKE_TARGET=${CROSS_COMPILER_TARGET_ARCH}-linux-musl
+ENV CMAKE_PROGRAMS="-DCMAKE_AR=/usr/bin/llvm-ar -DCMAKE_C_COMPILER=/usr/bin/clang \
+                    -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_NM=/usr/bin/llvm-nm \
+                    -DCMAKE_RANLIB=/usr/bin/llvm-ranlib -DLLVM_CONFIG_PATH=/usr/bin/llvm-config"
+ENV CMAKE_CROSS_ARGS="${CMAKE_PROGRAMS} ${CMAKE_HOST_ARGS} \
+                     -DCMAKE_INSTALL_PREFIX=${LLVM_SYSROOT}/usr ${CMAKE_HOST_ARGS} \
+                     -DCMAKE_CROSSCOMPILING=1 -DCMAKE_ASM_COMPILER_TARGET=${CMAKE_TARGET} \
+                     -DCMAKE_C_COMPILER_TARGET=${CMAKE_TARGET} -DCMAKE_CXX_COMPILER_TARGET=${CMAKE_TARGET} \
+                     -DCMAKE_C_COMPILER_WORKS=TRUE -DCMAKE_CXX_COMPILER_WORKS=TRUE \
+                     -DLLVM_DEFAULT_TARGET_TRIPLE=${CMAKE_TARGET}"
+ENV CMAKE_SHARED_FLAGS="--gcc-toolchain=${LLVM_SYSROOT}/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl \
+                        -fuse-ld=lld -nostdinc -nodefaultlibs -nostdlib \
+                        -isystem ${LLVM_SYSROOT}/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/ \
+                        -isystem ${LLVM_SYSROOT}/usr/include/"
+ENV CMAKE_C_FLAGS="${CMAKE_SHARED_FLAGS} -B${LLVM_SYSROOT}/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib/"
+ENV CMAKE_CXX_FLAGS="-nostdinc++ ${CMAKE_SHARED_FLAGS} --stdlib=libc++ --rtlib=compiler-rt"
+ENV CMAKE_CROSS="$CMAKE_COMMAND $CMAKE_CROSS_ARGS"
+
+RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
+    if [ -z "$SCCACHE_BUCKET" ]; then unset CC_WRAPPER; fi; \
+    if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
+    if [ -z "$CC_WRAPPER" ]; then export CMAKE_LAUNCHERS="-DCMAKE_C_COMPILER_LAUNCHER=$CC_WRAPPER -DCMAKE_CXX_COMPILER_LAUNCHER=$CC_WRAPPER"; fi; \
+    # Download and extract LLVM tarball for ${LLVM_VERSION} \
+    export REPOS=/tmp/llvm-project && \
+    cd /tmp && mkdir -p $REPOS && \
+    curl -fSLO https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz && \
+    tar -C $REPOS --strip-components=1 -xf llvm-project-${LLVM_VERSION}.src.tar.xz && \
+    # Generate host headers needed to build clang headers for ${CROSS_COMPILER_TARGET} \
+    cd $REPOS/llvm && mkdir build && cd build && \
+    $CMAKE_HOST -DLLVM_ENABLE_DOXYGEN=OFF .. && \
+    cd $REPOS/clang && mkdir build && cd build && \
+    $CMAKE_HOST $CMAKE_LAUNCHERS -DCMAKE_MODULE_PATH="$REPOS/llvm/build/cmake/modules/CMakeFiles;$REPOS/llvm/build/lib/cmake/llvm/" -DLLVM_ENABLE_LIBCXX:BOOL=ON -DLLVM_DIR="$REPOS/llvm" .. && \
+    make -j $(nproc) install-clang-resource-headers && \
+    # Generate and install sysroot libc++ headers \
+    cd $REPOS/libcxx && mkdir build && cd build && \
+    $CMAKE_CROSS $CMAKE_LAUNCHERS -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" -DCMAKE_C_IMPLICIT_LINK_DIRECTORIES= -DCMAKE_CXX_IMPLICIT_LINK_DIRECTORIES= -DLIBCXX_LINK_FLAGS=-fuse-ld=lld -DLIBCXX_GCC_TOOLCHAIN=$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl -DLIBCXX_HAS_MUSL_LIBC=1 -DLIBCXX_HAS_GCC_S_LIB=0 -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$REPOS/libcxxabi/include" -DLIBCXX_CXX_ABI_LIBRARY_PATH="$REPOS/libcxxabi/build/lib" -DLLVM_PATH="$REPOS/llvm" .. && \
+    make -j $(nproc) cxx_abi_headers generate-cxx-headers install-cxx-headers && \
+    # Build and install sysroot compiler-rt \
+    cd $REPOS/compiler-rt && mkdir build && cd build && \
+    $CMAKE_CROSS $CMAKE_LAUNCHERS -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS}" -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" -DCMAKE_C_IMPLICIT_LINK_DIRECTORIES= -DCMAKE_CXX_IMPLICIT_LINK_DIRECTORIES= -DCOMPILER_RT_BUILD_BUILTINS=ON -DCOMPILER_RT_BUILD_LIBFUZZER=OFF -DCOMPILER_RT_BUILD_MEMPROF=OFF -DCOMPILER_RT_BUILD_PROFILE=OFF -DCOMPILER_RT_BUILD_SANITIZERS=OFF -DCOMPILER_RT_BUILD_XRAY=OFF -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON -DLLVM_PATH="$REPOS/llvm" .. && \
+    make -j $(nproc) install-builtins && \
+    # Finish up musl libc build and install \
+    cd /tmp/musl-$MUSL_VERSION && \
+    make -j $(nproc) install && \
+    # Build libunwind \
+    cd $REPOS/libunwind && mkdir build && cd build && \
+    $CMAKE_CROSS $CMAKE_LAUNCHERS -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" -DLIBUNWIND_LINK_FLAGS=-fuse-ld=lld -DCMAKE_LLVM_SYSROOT=${LLVM_SYSROOT} -DLIBUNWIND_GCC_TOOLCHAIN=$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl -DLIBUNWIND_ENABLE_SHARED=0 -DLLVM_PATH="$REPOS/llvm" .. && \
+    make -j $(nproc) && \
+    # Build and install libcxxabi \
+    cd $REPOS/libcxxabi/ && mkdir build && cd build && \
+    $CMAKE_CROSS $CMAKE_LAUNCHERS -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" -DLIBCXXABI_HAS_CXA_THREAD_ATEXIT_IMPL=NO -DLIBCXXABI_LINK_FLAGS=-fuse-ld=lld -DLIBCXXABI_GCC_TOOLCHAIN=$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl -DCMAKE_SHARED_LINKER_FLAGS="-L$REPOS/libunwind/build/lib" -DLIBCXXABI_USE_LLVM_UNWINDER=1 -DLIBCXXABI_LIBUNWIND_PATH="$REPOS/libunwind" -DLIBCXXABI_LIBCXX_INCLUDES="$REPOS/libcxx/build/include/c++/v1/" -DLLVM_PATH="$REPOS/llvm" .. && \
+    make -j $(nproc) cxxabi_static && \
+    make -j $(nproc) install && \
+    # Build and install libc++ \
+    cd $REPOS/libcxx/build && \
+    make -j $(nproc) install && \
+    cd / && rm -r /tmp/*
+
 
 #############################################################################
 ## The Cross Compile image

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -45,10 +45,47 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     sccache --show-stats
 
+ENV LINUX_HEADER_VERSION="4.19.88"
+ARG MUSL_VERSION="1.2.2"
+
+ENV LLVM_SYSROOT="/sysroot/${CROSS_COMPILER_TARGET_ARCH}-musl"
+ENV MUSL_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl"
+
+# Create LLVM_SYSROOT
+RUN mkdir -p $LLVM_SYSROOT
+
+# Install linux headers in LLVM_SYSROOT
+RUN cd /tmp && \
+    curl --retry 5 -sSfL -O "https://github.com/sabotage-linux/kernel-headers/archive/v$LINUX_HEADER_VERSION.tar.gz" && \
+    tar xf v$LINUX_HEADER_VERSION.tar.gz && cd kernel-headers-$LINUX_HEADER_VERSION && \
+    make ARCH=${CROSS_COMPILER_TARGET_ARCH} prefix=$LLVM_SYSROOT/usr/ install && \
+    cd / && rm -r /tmp/*
+
+# Download and untar musl
+RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
+    if [ -z "$SCCACHE_BUCKET" ]; then unset CC_WRAPPER; fi; \
+    if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
+    curl -fSLo /tmp/musl.tar.gz https://www.musl-libc.org/releases/musl-$MUSL_VERSION.tar.gz && \
+    tar -C /tmp -xf /tmp/musl.tar.gz && \
+    cd /tmp/musl-$MUSL_VERSION && \
+    AR=llvm-ar RANLIB=llvm-ranlib CC="$CC_WRAPPER clang" \
+    CFLAGS="--target=$MUSL_TRIPLE" \
+    LDFLAGS="-fuse-ld=lld -L$LLVM_SYSROOT/usr/lib/linux/" \
+    LIBCC="-lclang_rt.builtins-${CROSS_COMPILER_TARGET_ARCH}" \
+    ./configure --prefix=$LLVM_SYSROOT/usr/$MUSL_TRIPLE \
+                --syslibdir=$LLVM_SYSROOT/usr/lib \
+                --build=${!BUILDARCH} \
+                --target=$MUSL_TRIPLE && \
+    make install-headers
+
 #############################################################################
 ## The Cross Compile image
 #############################################################################
 FROM --platform=${TARGETPLATFORM} ${BASE_IMAGE}
+
+# Copy in the cross compiled cargo tools from base
+COPY --from=build /out/tools/* /usr/local/bin/
+COPY --from=build /sysroot /sysroot
 
 ARG BUILDARCH
 ARG TARGETARCH
@@ -61,9 +98,6 @@ ARG SCCACHE_RECACHE
 ARG SCCACHE_SERVER_PORT=4226
 
 ARG CROSS_COMPILER_TARGET_ARCH
-
-# Copy in the cross compiled cargo tools from base
-COPY --from=build /out/tools/* /usr/local/bin/
 
 RUN rustup target add ${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl && \
     rustup target add ${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-gnu  && \

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -166,6 +166,28 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     rm -r /tmp/zlib
 
 
+## Install static -fPIC Rocksdb
+RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
+    if [ -z "$SCCACHE_BUCKET" ]; then unset CC_WRAPPER; fi; \
+    if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
+    echo "Building rocksdb" && \
+    git clone https://github.com/facebook/rocksdb.git --branch v6.22.1 --depth=1 /tmp/rocksdb; \
+    cd /tmp/rocksdb && \
+    export USE_CLANG=1 TARGET_OS=Linux PORTABLE=1 AR=llvm-ar; \
+    export TARGET_ARCHITECTURE=${CROSS_COMPILER_TARGET_ARCH}; \
+    export C_INCLUDES="-isystem $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/ -isystem $LLVM_SYSROOT/usr/lib/clang/${LLVM_VERSION}/include/ -isystem $LLVM_SYSROOT/usr/include/"; \
+    export CC="$CC_WRAPPER clang --target=${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl"; \
+    export EXTRA_CFLAGS="-nostdinc -fPIC $C_INCLUDES -nostdlib -nostdlib++ -nodefaultlibs -Wno-unused-command-line-argument"; \
+    export CXX="$CC_WRAPPER clang++ -nostdlib++ -fuse-ld=lld --target=${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl"; \
+    export EXTRA_CXXFLAGS="-nostdinc -nostdinc++ -fPIC -isystem $LLVM_SYSROOT/usr/include/c++/v1/ -isystem $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/ -D _LIBCPP_HAS_MUSL_LIBC $C_INCLUDES -Wno-unused-command-line-argument "; \
+    export CFLAGS="$EXTRA_CFLAGS -L$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib"; \
+    DISABLE_WARNING_AS_ERROR=1 make -j$(nproc) static_lib && \
+    cp librocksdb.a* $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib && \
+    cp -r include/* $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/ && \
+    sccache --show-stats && \
+    rm -R /tmp/rocksdb/
+
+
 #############################################################################
 ## The Cross Compile image
 #############################################################################
@@ -187,6 +209,15 @@ ARG SCCACHE_RECACHE
 ARG SCCACHE_SERVER_PORT=4226
 
 ARG CROSS_COMPILER_TARGET_ARCH
+ENV LLVM_SYSROOT="/sysroot/${CROSS_COMPILER_TARGET_ARCH}-musl"
+ENV MUSL_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl"
+ENV GNU_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-gnu"
+
+# Legacy rocksdb paths
+RUN mkdir -p /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/ && \
+    cp $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib/librocksdb.a* /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib && \
+    cp -r $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/rocksdb /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/include/ && \
+    cp -r $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/rocksdb /usr/include/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/
 
 RUN rustup target add ${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl && \
     rustup target add ${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-gnu  && \
@@ -238,32 +269,5 @@ ENV PKG_CONFIG_ALLOW_CROSS=true \
     PKG_CONFIG_ALL_STATIC=true \
     LIBZ_SYS_STATIC=1 \
     PLATFORM_LDFLAGS="-static-libstdc++ -static-libgcc"
-
-## Install static -fPIC Rocksdb
-RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
-    if [ -z "$SCCACHE_BUCKET" ]; then unset CC_WRAPPER; fi; \
-    if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
-    echo "Building rocksdb" && \
-    cd /tmp && \
-    git clone https://github.com/facebook/rocksdb.git && \
-    cd rocksdb && \
-    git checkout v6.22.1 && \
-    PORTABLE=1 CCFLAGS=-fPIC CXXFLAGS=-fPIC \
-    CC="$CC_WRAPPER ${CROSS_COMPILER_TARGET_ARCH}-linux-musl-gcc" CXX="$CC_WRAPPER ${CROSS_COMPILER_TARGET_ARCH}-linux-musl-g++" \
-    make -j$(nproc) static_lib && \
-    mkdir -p /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib && \
-    mkdir /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/include && \
-    cp librocksdb.a* /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib && \
-    cp -r include /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/ && \
-    cp -r include/* /usr/include/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/ && \
-    sccache --show-stats && \
-    rm -R /tmp/rocksdb/
-
-ENV CC_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_musl=${CROSS_COMPILER_TARGET_ARCH}-linux-musl-gcc \
-    CXX_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_musl=${CROSS_COMPILER_TARGET_ARCH}-linux-musl-g++ \
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
-    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc
-
-ENV PCRE2_SYS_STATIC=1
 
 CMD ["bash"]

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -51,6 +51,8 @@ ARG MUSL_VERSION="1.2.2"
 ENV LLVM_SYSROOT="/sysroot/${CROSS_COMPILER_TARGET_ARCH}-musl"
 ENV MUSL_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl"
 
+ENV MAKEFLAGS=--silent -j $(nproc)
+
 # Create LLVM_SYSROOT
 RUN mkdir -p $LLVM_SYSROOT
 
@@ -58,7 +60,7 @@ RUN mkdir -p $LLVM_SYSROOT
 RUN cd /tmp && \
     curl --retry 5 -sSfL -O "https://github.com/sabotage-linux/kernel-headers/archive/v$LINUX_HEADER_VERSION.tar.gz" && \
     tar xf v$LINUX_HEADER_VERSION.tar.gz && cd kernel-headers-$LINUX_HEADER_VERSION && \
-    make --silent -j $(nproc) ARCH=${CROSS_COMPILER_TARGET_ARCH} prefix=$LLVM_SYSROOT/usr/ install && \
+    make ARCH=${CROSS_COMPILER_TARGET_ARCH} prefix=$LLVM_SYSROOT/usr/ install && \
     cd / && rm -r /tmp/*
 
 # Download and untar musl
@@ -76,7 +78,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
                 --syslibdir=$LLVM_SYSROOT/usr/lib \
                 --build=${!BUILDARCH} \
                 --target=$MUSL_TRIPLE 2>&1 >/dev/null && \
-    make --silent -j $(nproc) install-headers
+    make install-headers
 
 # Configure cmake for building llvm headers, compiler-rt and builtins
 ENV CMAKE_COMMAND="cmake -q --parallel=$(nproc) --log-level=WARNING -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_INSTALL_MESSAGE=NEVER"
@@ -114,30 +116,30 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     $CMAKE_HOST -DLLVM_ENABLE_DOXYGEN=OFF .. && \
     cd $REPOS/clang && mkdir build && cd build && \
     $CMAKE_HOST $CMAKE_LAUNCHERS -DCMAKE_MODULE_PATH="$REPOS/llvm/build/cmake/modules/CMakeFiles;$REPOS/llvm/build/lib/cmake/llvm/" -DLLVM_ENABLE_LIBCXX:BOOL=ON -DLLVM_DIR="$REPOS/llvm" .. && \
-    make --silent -j $(nproc) install-clang-resource-headers && \
+    make install-clang-resource-headers && \
     # Generate and install sysroot libc++ headers \
     cd $REPOS/libcxx && mkdir build && cd build && \
     $CMAKE_CROSS $CMAKE_LAUNCHERS -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" -DCMAKE_C_IMPLICIT_LINK_DIRECTORIES= -DCMAKE_CXX_IMPLICIT_LINK_DIRECTORIES= -DLIBCXX_LINK_FLAGS=-fuse-ld=lld -DLIBCXX_GCC_TOOLCHAIN=$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl -DLIBCXX_HAS_MUSL_LIBC=1 -DLIBCXX_HAS_GCC_S_LIB=0 -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$REPOS/libcxxabi/include" -DLIBCXX_CXX_ABI_LIBRARY_PATH="$REPOS/libcxxabi/build/lib" -DLLVM_PATH="$REPOS/llvm" .. && \
-    make --silent -j $(nproc) cxx_abi_headers generate-cxx-headers install-cxx-headers && \
+    make cxx_abi_headers generate-cxx-headers install-cxx-headers && \
     # Build and install sysroot compiler-rt \
     cd $REPOS/compiler-rt && mkdir build && cd build && \
     $CMAKE_CROSS $CMAKE_LAUNCHERS -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS}" -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" -DCMAKE_C_IMPLICIT_LINK_DIRECTORIES= -DCMAKE_CXX_IMPLICIT_LINK_DIRECTORIES= -DCOMPILER_RT_BUILD_BUILTINS=ON -DCOMPILER_RT_BUILD_LIBFUZZER=OFF -DCOMPILER_RT_BUILD_MEMPROF=OFF -DCOMPILER_RT_BUILD_PROFILE=OFF -DCOMPILER_RT_BUILD_SANITIZERS=OFF -DCOMPILER_RT_BUILD_XRAY=OFF -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON -DLLVM_PATH="$REPOS/llvm" .. && \
-    make --silent -j $(nproc) install-builtins && \
+    make install-builtins && \
     # Finish up musl libc build and install \
     cd /tmp/musl-$MUSL_VERSION && \
-    make --silent -j $(nproc) install && \
+    make install && \
     # Build libunwind \
     cd $REPOS/libunwind && mkdir build && cd build && \
     $CMAKE_CROSS $CMAKE_LAUNCHERS -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" -DLIBUNWIND_LINK_FLAGS=-fuse-ld=lld -DCMAKE_LLVM_SYSROOT=${LLVM_SYSROOT} -DLIBUNWIND_GCC_TOOLCHAIN=$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl -DLIBUNWIND_ENABLE_SHARED=0 -DLLVM_PATH="$REPOS/llvm" .. && \
-    make --silent -j $(nproc) && \
+    make && \
     # Build and install libcxxabi \
     cd $REPOS/libcxxabi/ && mkdir build && cd build && \
     $CMAKE_CROSS $CMAKE_LAUNCHERS -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" -DLIBCXXABI_HAS_CXA_THREAD_ATEXIT_IMPL=NO -DLIBCXXABI_LINK_FLAGS=-fuse-ld=lld -DLIBCXXABI_GCC_TOOLCHAIN=$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl -DCMAKE_SHARED_LINKER_FLAGS="-L$REPOS/libunwind/build/lib" -DLIBCXXABI_USE_LLVM_UNWINDER=1 -DLIBCXXABI_LIBUNWIND_PATH="$REPOS/libunwind" -DLIBCXXABI_LIBCXX_INCLUDES="$REPOS/libcxx/build/include/c++/v1/" -DLLVM_PATH="$REPOS/llvm" .. && \
-    make --silent -j $(nproc) cxxabi_static && \
-    make --silent -j $(nproc) install && \
+    make cxxabi_static && \
+    make install && \
     # Build and install libc++ \
     cd $REPOS/libcxx/build && \
-    make --silent -j $(nproc) install && \
+    make install && \
     cd / && rm -r /tmp/*
 
 
@@ -158,10 +160,10 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     LDFLAGS="-L$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib" \
     # Legacy path \
     ./configure --static --shared --prefix=/usr/local/musl || cat configure.log && \
-    make -j$(nproc) install && \
+    make install && \
     # sysroot \
     ./configure --static --shared --prefix=$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl || cat configure.log && \
-    make -j$(nproc) install && \
+    make install && \
     sccache --show-stats && \
     rm -r /tmp/zlib
 
@@ -181,7 +183,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     export CXX="$CC_WRAPPER clang++ -nostdlib++ -fuse-ld=lld --target=${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl"; \
     export EXTRA_CXXFLAGS="-nostdinc -nostdinc++ -fPIC -isystem $LLVM_SYSROOT/usr/include/c++/v1/ -isystem $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/ -D _LIBCPP_HAS_MUSL_LIBC $C_INCLUDES -Wno-unused-command-line-argument "; \
     export CFLAGS="$EXTRA_CFLAGS -L$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib"; \
-    DISABLE_WARNING_AS_ERROR=1 make -j$(nproc) static_lib && \
+    DISABLE_WARNING_AS_ERROR=1 make static_lib && \
     cp librocksdb.a* $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib && \
     cp -r include/* $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/ && \
     sccache --show-stats && \

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -219,11 +219,29 @@ ENV LLVM_SYSROOT="/sysroot/${CROSS_COMPILER_TARGET_ARCH}-musl"
 ENV MUSL_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl"
 ENV GNU_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-gnu"
 
-# Legacy rocksdb paths
-RUN mkdir -p /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/ && \
+# Copy files around to ensure changes are compatible with agent 3.3 and 3.4
+RUN mkdir -p /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/include && \
+    mkdir -p /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib && \
     cp $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib/librocksdb.a* /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib && \
-    cp -r $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/rocksdb /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/include/ && \
-    cp -r $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/rocksdb /usr/include/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/
+    cp -r $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/rocksdb/ /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/include/ && \
+    cp -r $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/rocksdb/ /usr/include/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/ && \
+    cp -r $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/* /usr/local/include/ && \
+    cp -r $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl /usr/local/${CROSS_COMPILER_TARGET_ARCH}-linux-musl && \
+    cp -r $LLVM_SYSROOT/usr/lib/* /usr/local/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib/ && \
+    ln -s /usr/lib/llvm-${LLVM_MAJOR_VERSION}/bin/llvm-strip /usr/local/bin/${CROSS_COMPILER_TARGET_ARCH}-linux-gnu-strip && \
+    ln -s /usr/lib/llvm-${LLVM_MAJOR_VERSION}/bin/llvm-strip /usr/local/bin/${CROSS_COMPILER_TARGET_ARCH}-linux-musl-strip && \
+    # Build a fake libstdc++ from libc++ and libc++abi to work around some rust crate build.rs deficiencies \
+    printf "create /usr/local/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib/libstdc++.a\naddlib /usr/local/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib/libc++.a\naddlib /usr/local/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/lib/libc++abi.a\nsave\nend" | llvm-ar -M && \
+    printf "create $LLVM_SYSROOT/usr/lib/libstdc++.a\naddlib $LLVM_SYSROOT/usr/lib/libc++.a\naddlib $LLVM_SYSROOT/usr/lib/libc++abi.a\nsave\nend" | llvm-ar -M ;
+
+# Some legacy compat linkers
+RUN printf "#!/usr/bin/env bash\nclang -fuse-ld=lld --target=aarch64-unknown-linux-musl \$@" > /usr/local/bin/aarch64-unknown-linux-musl-clang && \
+    chmod +x /usr/local/bin/aarch64-unknown-linux-musl-clang && \
+    printf "#!/usr/bin/env bash\nclang -fuse-ld=lld --target=x86_64-unknown-linux-musl \$@" > /usr/local/bin/x86_64-unknown-linux-musl-clang && \
+    chmod +x /usr/local/bin/x86_64-unknown-linux-musl-clang
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="/usr/local/bin/aarch64-unknown-linux-musl-clang"
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="/usr/local/bin/x86_64-unknown-linux-musl-clang"
 
 RUN rustup target add ${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl && \
     rustup target add ${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-gnu  && \
@@ -237,16 +255,21 @@ ENV COMMON_RUSTFLAGS="-Clinker=clang -Clink-args=-fuse-ld=lld -Lnative=${LLVM_SY
 ENV SHARED_RUSTFLAGS="${COMMON_RUSTFLAGS}"
 ENV STATIC_RUSTFLAGS="${COMMON_RUSTFLAGS} -Ctarget-feature=+crt-static -Clink-args=-static \
                       -Clink-args=-nodefaultlibs -Clink-args=-nostdlib -Clink-args=-nostdlib++\
-                      -Clink-args=-stdlib=c++ -Clink-args=-static-libgcc -l static=c++\
-                      -Clink-args=-static-libstdc++"
+                      -Clink-args=-stdlib=c++ -l static=c++ -l static=c++abi \
+                      -Lnative=$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib"
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="${STATIC_RUSTFLAGS} -Clink-args=--target=aarch64-unknown-linux-musl"
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="${STATIC_RUSTFLAGS} -Clink-args=--target=x86_64-unknown-linux-musl"
 
-ENV CC_${MUSL_TRIPLE}="clang"
-ENV CFLAGS_${MUSL_TRIPLE}="--target=${MUSL_TRIPLE} -fuse-ld=lld -static -fPIC -nostdlib -nodefaultlibs -nostdinc ${MUSL_C_INCLUDES} -L ${LLVM_SYSROOT}/usr/${MUSL_TRIPLE}/lib -lc  -L ${LLVM_SYSROOT}/usr/lib/linux/ -lclang_rt.builtins-${CROSS_COMPILER_TARGET_ARCH}"
-ENV CXX_${MUSL_TRIPLE}="clang++"
-ENV CXXFLAGS_${MUSL_TRIPLE}="--target=${MUSL_TRIPLE} -fuse-ld=lld -nostdinc -static-libstdc++ --stdlib=c++ --rtlib=compiler-rt -nodefaultlibs -nostdinc++ ${MUSL_CXX_INCLUDES} ${MUSL_C_INCLUDES}"
+ENV CC_aarch64_unknown_linux_musl="clang"
+ENV CFLAGS_aarch64_unknown_linux_musl="--target=aarch64-unknown-linux-musl -fuse-ld=lld -static -fPIC -nostdlib -nodefaultlibs -nostdinc -isystem $LLVM_SYSROOT/usr/lib/clang/${LLVM_VERSION}/include/ -isystem $LLVM_SYSROOT/usr/aarch64-unknown-linux-musl/include/ -isystem $LLVM_SYSROOT/usr/include/linux/ -L ${LLVM_SYSROOT}/usr/aarch64-unknown-linux-musl/lib -lc  -L ${LLVM_SYSROOT}/usr/lib/linux/ -lclang_rt.builtins-aarch64"
+ENV CXX_aarch64_unknown_linux_musl="clang++"
+ENV CXXFLAGS_aarch64_unknown_linux_musl="--target=aarch64-unknown-linux-musl -fuse-ld=lld -nostdinc -static-libstdc++ --stdlib=c++ --rtlib=compiler-rt -nodefaultlibs -nostdinc++ -isystem $LLVM_SYSROOT/usr/include/c++/v1/ -isystem $LLVM_SYSROOT/usr/aarch64-unknown-linux-musl/include/  -isystem $LLVM_SYSROOT/usr/lib/clang/${LLVM_VERSION}/include/ -isystem $LLVM_SYSROOT/usr/aarch64-unknown-linux-musl/include/ -isystem $LLVM_SYSROOT/usr/include/linux/ "
+
+ENV CC_x86_64_unknown_linux_musl="clang"
+ENV CFLAGS_x86_64_unknown_linux_musl="--target=x86_64-unknown-linux-musl -fuse-ld=lld -static -fPIC -nostdlib -nodefaultlibs -nostdinc -isystem $LLVM_SYSROOT/usr/lib/clang/${LLVM_VERSION}/include/ -isystem $LLVM_SYSROOT/usr/x86_64-unknown-linux-musl/include/ -isystem $LLVM_SYSROOT/usr/include/linux/ -L ${LLVM_SYSROOT}/usr/x86_64-unknown-linux-musl/lib -lc  -L ${LLVM_SYSROOT}/usr/lib/linux/ -lclang_rt.builtins-x86_64"
+ENV CXX_x86_64_unknown_linux_musl="clang++"
+ENV CXXFLAGS_x86_64_unknown_linux_musl="--target=x86_64-unknown-linux-musl -fuse-ld=lld -nostdinc -static-libstdc++ --stdlib=c++ --rtlib=compiler-rt -nodefaultlibs -nostdinc++ -isystem $LLVM_SYSROOT/usr/include/c++/v1/ -isystem $LLVM_SYSROOT/usr/x86_64-unknown-linux-musl/include/  -isystem $LLVM_SYSROOT/usr/lib/clang/${LLVM_VERSION}/include/ -isystem $LLVM_SYSROOT/usr/x86_64-unknown-linux-musl/include/ -isystem $LLVM_SYSROOT/usr/include/linux/ "
 
 ENV PCRE2_SYS_STATIC=1
 ENV SYSTEMD_LIB_DIR="/lib/${CROSS_COMPILER_TARGET_ARCH}-linux-gnu"

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -223,26 +223,6 @@ RUN rustup target add ${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl && \
     rustup target add ${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-gnu  && \
     chmod -R a+rw $RUSTUP_HOME $CARGO_HOME
 
-## Install a musl cross compiler for ${CROSS_COMPILER_TARGET_ARCH} using musl-cross-make
-RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
-    if [ -z "$SCCACHE_BUCKET" ]; then unset CC_WRAPPER; fi; \
-    if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
-    mkdir /tmp/musl-cross && cd /tmp/musl-cross && \
-    curl --retry 3 -sSfL "https://github.com/richfelker/musl-cross-make/archive/v0.9.9.tar.gz" -O &&\
-    tar --strip-components=1 -xzf "v0.9.9.tar.gz" && \
-    echo "GCC_CONFIG += --enable-default-pie" >> config.mak && \
-    echo 'COMMON_CONFIG="CC=$(CC_WRAPPER) $(CC)"' >> config.mak && \
-    echo 'COMMON_CONFIG += "CXX=$(CC_WRAPPER) $(CXX)"' >> config.mak && \
-    echo 'COMMON_CONFIG += "STAGE_CC_WRAPPER=$(CC_WRAPPER)"' >> config.mak && \
-    make --silent install "-j$(nproc)" \
-        CC_WRAPPER=$CC_WRAPPER \
-        DL_CMD='curl --retry 3 -sSfL -C - -o' \
-        LINUX_HEADERS_SITE=https://ci-mirrors.rust-lang.org/rustc/sabotage-linux-tarballs \
-        OUTPUT=/usr/local/ \
-        TARGET=${CROSS_COMPILER_TARGET_ARCH}-linux-musl > build.log && \
-    sccache --show-stats && \
-    rm -rf /tmp/musl-cross
-
 ## Set up default cargo env vars for cross compiling
 ENV MUSL_C_INCLUDES="-isystem $LLVM_SYSROOT/usr/lib/clang/${LLVM_VERSION}/include/ -isystem $LLVM_SYSROOT/usr/${MUSL_TRIPLE}/include/ -isystem $LLVM_SYSROOT/usr/include/linux/"
 ENV MUSL_CXX_INCLUDES="-isystem $LLVM_SYSROOT/usr/include/c++/v1/ -isystem $LLVM_SYSROOT/usr/${MUSL_TRIPLE}/include/ "

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -141,6 +141,31 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     cd / && rm -r /tmp/*
 
 
+## Install static Zlib
+ARG ZLIB_VERSION=1.2.12
+
+RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
+    if [ -z "$SCCACHE_BUCKET" ]; then unset CC_WRAPPER; fi; \
+    if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
+    mkdir -p /tmp/zlib && cd /tmp/zlib && \
+    curl -fLO "http://zlib.net/zlib-$ZLIB_VERSION.tar.gz" && \
+    tar xzf "zlib-$ZLIB_VERSION.tar.gz" && cd "zlib-$ZLIB_VERSION" && \
+    echo "Building zlib" && \
+    cd /tmp/zlib/zlib-$ZLIB_VERSION && \
+    CC="$CC_WRAPPER clang --target=${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl" \
+    CFLAGS="-nostdinc -isystem $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/" \
+    LDSHARED="lld" AR=llvm-ar RANLIB=llvm-ranlib \
+    LDFLAGS="-L$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib" \
+    # Legacy path \
+    ./configure --static --shared --prefix=/usr/local/musl || cat configure.log && \
+    make -j$(nproc) install && \
+    # sysroot \
+    ./configure --static --shared --prefix=$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl || cat configure.log && \
+    make -j$(nproc) install && \
+    sccache --show-stats && \
+    rm -r /tmp/zlib
+
+
 #############################################################################
 ## The Cross Compile image
 #############################################################################
@@ -149,6 +174,7 @@ FROM --platform=${TARGETPLATFORM} ${BASE_IMAGE}
 # Copy in the cross compiled cargo tools from base
 COPY --from=build /out/tools/* /usr/local/bin/
 COPY --from=build /sysroot /sysroot
+COPY --from=build /usr/local/musl /usr/local/musl
 
 ARG BUILDARCH
 ARG TARGETARCH
@@ -186,19 +212,27 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     sccache --show-stats && \
     rm -rf /tmp/musl-cross
 
-## Install static Zlib
-ARG ZLIB_VERSION=1.2.12
-RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
-    if [ -z "$SCCACHE_BUCKET" ]; then unset CC_WRAPPER; fi; \
-    if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
-    echo "Building zlib" && \
-    cd /tmp && \
-    curl -fLO "http://zlib.net/zlib-$ZLIB_VERSION.tar.gz" && \
-    tar xzf "zlib-$ZLIB_VERSION.tar.gz" && cd "zlib-$ZLIB_VERSION" && \
-    CC="$CC_WRAPPER ${CROSS_COMPILER_TARGET_ARCH}-linux-musl-gcc" ./configure --static --prefix=/usr/local/musl && \
-    make -j$(nproc) && make install && \
-    sccache --show-stats && \
-    rm -r /tmp/*
+## Set up default cargo env vars for cross compiling
+ENV MUSL_C_INCLUDES="-isystem $LLVM_SYSROOT/usr/lib/clang/${LLVM_VERSION}/include/ -isystem $LLVM_SYSROOT/usr/${MUSL_TRIPLE}/include/ -isystem $LLVM_SYSROOT/usr/include/linux/"
+ENV MUSL_CXX_INCLUDES="-isystem $LLVM_SYSROOT/usr/include/c++/v1/ -isystem $LLVM_SYSROOT/usr/${MUSL_TRIPLE}/include/ "
+
+ENV COMMON_RUSTFLAGS="-Clinker=clang -Clink-args=-fuse-ld=lld -Lnative=${LLVM_SYSROOT}/usr/lib/"
+ENV SHARED_RUSTFLAGS="${COMMON_RUSTFLAGS}"
+ENV STATIC_RUSTFLAGS="${COMMON_RUSTFLAGS} -Ctarget-feature=+crt-static -Clink-args=-static \
+                      -Clink-args=-nodefaultlibs -Clink-args=-nostdlib -Clink-args=-nostdlib++\
+                      -Clink-args=-stdlib=c++ -Clink-args=-static-libgcc -l static=c++\
+                      -Clink-args=-static-libstdc++"
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="${STATIC_RUSTFLAGS} -Clink-args=--target=aarch64-unknown-linux-musl"
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="${STATIC_RUSTFLAGS} -Clink-args=--target=x86_64-unknown-linux-musl"
+
+ENV CC_${MUSL_TRIPLE}="clang"
+ENV CFLAGS_${MUSL_TRIPLE}="--target=${MUSL_TRIPLE} -fuse-ld=lld -static -fPIC -nostdlib -nodefaultlibs -nostdinc ${MUSL_C_INCLUDES} -L ${LLVM_SYSROOT}/usr/${MUSL_TRIPLE}/lib -lc  -L ${LLVM_SYSROOT}/usr/lib/linux/ -lclang_rt.builtins-${CROSS_COMPILER_TARGET_ARCH}"
+ENV CXX_${MUSL_TRIPLE}="clang++"
+ENV CXXFLAGS_${MUSL_TRIPLE}="--target=${MUSL_TRIPLE} -fuse-ld=lld -nostdinc -static-libstdc++ --stdlib=c++ --rtlib=compiler-rt -nodefaultlibs -nostdinc++ ${MUSL_CXX_INCLUDES} ${MUSL_C_INCLUDES}"
+
+ENV PCRE2_SYS_STATIC=1
+ENV SYSTEMD_LIB_DIR="/lib/${CROSS_COMPILER_TARGET_ARCH}-linux-gnu"
 
 ENV PKG_CONFIG_ALLOW_CROSS=true \
     PKG_CONFIG_ALL_STATIC=true \

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -51,7 +51,6 @@ ARG MUSL_VERSION="1.2.2"
 ENV LLVM_SYSROOT="/sysroot/${CROSS_COMPILER_TARGET_ARCH}-musl"
 ENV MUSL_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl"
 
-ENV MAKEFLAGS=--silent -j $(nproc)
 
 # Create LLVM_SYSROOT
 RUN mkdir -p $LLVM_SYSROOT
@@ -60,6 +59,7 @@ RUN mkdir -p $LLVM_SYSROOT
 RUN cd /tmp && \
     curl --retry 5 -sSfL -O "https://github.com/sabotage-linux/kernel-headers/archive/v$LINUX_HEADER_VERSION.tar.gz" && \
     tar xf v$LINUX_HEADER_VERSION.tar.gz && cd kernel-headers-$LINUX_HEADER_VERSION && \
+    MAKEFLAGS="--silent -j $(nproc)" && \
     make ARCH=${CROSS_COMPILER_TARGET_ARCH} prefix=$LLVM_SYSROOT/usr/ install && \
     cd / && rm -r /tmp/*
 
@@ -70,6 +70,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     curl -fSLo /tmp/musl.tar.gz https://www.musl-libc.org/releases/musl-$MUSL_VERSION.tar.gz && \
     tar -C /tmp -xf /tmp/musl.tar.gz && \
     cd /tmp/musl-$MUSL_VERSION && \
+    MAKEFLAGS="--silent -j $(nproc)" && \
     AR=llvm-ar RANLIB=llvm-ranlib CC="$CC_WRAPPER clang" \
     CFLAGS="--target=$MUSL_TRIPLE" \
     LDFLAGS="-fuse-ld=lld -L$LLVM_SYSROOT/usr/lib/linux/" \
@@ -107,6 +108,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
     if [ -z "$CC_WRAPPER" ]; then export CMAKE_LAUNCHERS="-DCMAKE_C_COMPILER_LAUNCHER=$CC_WRAPPER -DCMAKE_CXX_COMPILER_LAUNCHER=$CC_WRAPPER"; fi; \
     # Download and extract LLVM tarball for ${LLVM_VERSION} \
+    export MAKEFLAGS="--silent -j $(nproc)" && \
     export REPOS=/tmp/llvm-project && \
     cd /tmp && mkdir -p $REPOS && \
     curl -fSLO https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz && \
@@ -149,15 +151,16 @@ ARG ZLIB_VERSION=1.2.12
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     if [ -z "$SCCACHE_BUCKET" ]; then unset CC_WRAPPER; fi; \
     if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
+    export MAKEFLAGS="--silent -j $(nproc)" && \
     mkdir -p /tmp/zlib && cd /tmp/zlib && \
     curl -fLO "http://zlib.net/zlib-$ZLIB_VERSION.tar.gz" && \
     tar xzf "zlib-$ZLIB_VERSION.tar.gz" && cd "zlib-$ZLIB_VERSION" && \
     echo "Building zlib" && \
     cd /tmp/zlib/zlib-$ZLIB_VERSION && \
-    CC="$CC_WRAPPER clang --target=${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl" \
+    export CC="$CC_WRAPPER clang --target=${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl" \
     CFLAGS="-nostdinc -isystem $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/" \
     LDSHARED="lld" AR=llvm-ar RANLIB=llvm-ranlib \
-    LDFLAGS="-L$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib" \
+    LDFLAGS="-L$LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/lib"; \
     # Legacy path \
     ./configure --static --shared --prefix=/usr/local/musl || cat configure.log && \
     make install && \
@@ -175,6 +178,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     echo "Building rocksdb" && \
     git clone https://github.com/facebook/rocksdb.git --branch v6.22.1 --depth=1 /tmp/rocksdb; \
     cd /tmp/rocksdb && \
+    export MAKEFLAGS="--silent -j $(nproc)"; \
     export USE_CLANG=1 TARGET_OS=Linux PORTABLE=1 AR=llvm-ar; \
     export TARGET_ARCHITECTURE=${CROSS_COMPILER_TARGET_ARCH}; \
     export C_INCLUDES="-isystem $LLVM_SYSROOT/usr/${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl/include/ -isystem $LLVM_SYSROOT/usr/lib/clang/${LLVM_VERSION}/include/ -isystem $LLVM_SYSROOT/usr/include/"; \

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -37,17 +37,17 @@ RUN DEPS="ca-certificates curl file m4 make locales pkg-config xz-utils cmake \
           libc++-${LLVM_MAJOR_VERSION}-dev lldb-${LLVM_MAJOR_VERSION}\
           systemd libsystemd-dev patch \
           libssl-dev bzip2 gcc g++ libtool m4 libc6-dev" \
-  && apt-get update \
+  && apt-get update  > /dev/null \
   && apt-key add /llvm-snapshot.gpg.key \
-  && apt-get install -y --no-install-recommends software-properties-common \
+  && apt-get install -y --no-install-recommends software-properties-common > /dev/null \
   && add-apt-repository "deb http://apt.llvm.org/${VARIANT_VERSION}/ llvm-toolchain-${VARIANT_VERSION}-${LLVM_MAJOR_VERSION} main" \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends $DEPS \
+  && apt-get update > /dev/null \
+  && apt-get install -y --no-install-recommends $DEPS > /dev/null \
   && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
   && locale-gen en_US.UTF-8 \
   && /usr/sbin/update-locale LANG=en_US.UTF-8 \
-  && apt-get autoremove -y \
-  && apt-get clean \
+  && apt-get autoremove -y > /dev/null \
+  && apt-get clean > /dev/null \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_MAJOR_VERSION} 100 && \
@@ -58,14 +58,14 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_MAJ
     update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-${LLVM_MAJOR_VERSION} 100 && \
     update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/lib/llvm-${LLVM_MAJOR_VERSION}/bin/llvm-strip 100
 
-RUN unmunch /usr/share/hunspell/en_GB.dic /usr/share/hunspell/en_GB.aff | grep -v "'s" > /dict.txt
+RUN unmunch /usr/share/hunspell/en_GB.dic /usr/share/hunspell/en_GB.aff 2> /dev/null | grep -v "'s" > /dict.txt
 
 ARG VERSION="stable"
 
 # Install rust
 ENV CARGO_HOME=/opt/rust/cargo
 RUN curl -L https://sh.rustup.rs -sSf | \
-    sh -s -- -y --default-toolchain $VERSION --component clippy rustfmt --profile minimal --no-modify-path && \
+    sh -s -- -q -y --default-toolchain $VERSION --component clippy rustfmt --profile minimal --no-modify-path && \
     chmod -R a+rw $RUSTUP_HOME $CARGO_HOME
 
 # Install sccache

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -104,10 +104,15 @@ ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_AR=llvm-ar
 
 # Set up basic gnu C configuration for to use clang as the linker driver, llvm-ar, ETC
-ENV CC_${GNU_TRIPLE}="clang"
-ENV CFLAGS_${GNU_TRIPLE}="--target=${GNU_TRIPLE} -fuse-ld=lld -fPIC"
-ENV CXX_${GNU_TRIPLE}="clang++"
-ENV CXXFLAGS_${GNU_TRIPLE}="--target=${GNU_TRIPLE} -fuse-ld=lld"
+ENV CC_aarch64_unknown_linux_gnu="clang"
+ENV CFLAGS_aarch64_unknown_linux_gnu="--target=aarch64-unknown-linux-gnu -fuse-ld=lld -fPIC"
+ENV CXX_aarch64_unknown_linux_gnu="clang++"
+ENV CXXFLAGS_aarch64_unknown_linux_gnu="--target=aarch64-unknown-linux-gnu -fuse-ld=lld -fPIC"
+
+ENV CC_x86_64_unknown_linux_gnu="clang"
+ENV CFLAGS_x86_64_unknown_linux_gnu="--target=x86_64-unknown-linux-gnu -fuse-ld=lld -fPIC"
+ENV CXX_x86_64_unknown_linux_gnu="clang++"
+ENV CXXFLAGS_x86_64_unknown_linux_gnu="--target=x86_64-unknown-linux-gnu -fuse-ld=lld -fPIC"
 
 ENV RUSTC_WRAPPER="/usr/local/bin/sccache"
 ENV CC_WRAPPER="/usr/local/bin/sccache"


### PR DESCRIPTION
This PR replaces the musl gcc, g++, libc and stdlibc++ toolchain we were previously building with the precompiled upstream clang plus a much simpler musl libc + clang libc++ build.

This has a couple of advantages:
1. We're cutting out 2 custom compile-from-source compilers and the platform specific binutils they required and replacing it with one compiler and set of binutils.
2. As clang is natively a cross compiler we are also able to perform the compilation natively and simple copy the generated binaries over into the final image rather than running a full compilation under emulation, as suggested by docker as the strategy for speeding up multi-arch builds [here](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/)