### PR TITLE
Fix up a bad rebase on previous branch

### DIFF
--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -50,9 +50,6 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
 #############################################################################
 FROM --platform=${TARGETPLATFORM} ${BASE_IMAGE}
 
-# Copy in the cross compiled cargo tools from base
-COPY --from=build /out/tools/* /usr/local/bin/
-
 ARG BUILDARCH
 ARG TARGETARCH
 
@@ -64,9 +61,6 @@ ARG SCCACHE_RECACHE
 ARG SCCACHE_SERVER_PORT=4226
 
 ARG CROSS_COMPILER_TARGET_ARCH
-ENV LLVM_SYSROOT="/sysroot/${CROSS_COMPILER_TARGET_ARCH}-musl"
-ENV MUSL_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl"
-ENV GNU_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-gnu"
 
 # Copy in the cross compiled cargo tools from base
 COPY --from=build /out/tools/* /usr/local/bin/
@@ -94,37 +88,6 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
         TARGET=${CROSS_COMPILER_TARGET_ARCH}-linux-musl && \
     sccache --show-stats && \
     rm -rf /tmp/musl-cross
-
-# Some legacy compat linkers
-RUN printf "#!/usr/bin/env bash\nclang -fuse-ld=lld --target=aarch64-unknown-linux-musl \$@" > /usr/local/bin/aarch64-unknown-linux-musl-clang && \
-    chmod +x /usr/local/bin/aarch64-unknown-linux-musl-clang && \
-    printf "#!/usr/bin/env bash\nclang -fuse-ld=lld --target=x86_64-unknown-linux-musl \$@" > /usr/local/bin/x86_64-unknown-linux-musl-clang && \
-    chmod +x /usr/local/bin/x86_64-unknown-linux-musl-clang
-
-ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="/usr/local/bin/aarch64-unknown-linux-musl-clang"
-ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="/usr/local/bin/x86_64-unknown-linux-musl-clang"
-
-## Set up default cargo env vars for cross compiling
-ENV MUSL_C_INCLUDES="-isystem $LLVM_SYSROOT/usr/lib/clang/${LLVM_VERSION}/include/ -isystem $LLVM_SYSROOT/usr/${MUSL_TRIPLE}/include/ -isystem $LLVM_SYSROOT/usr/include/linux/"
-ENV MUSL_CXX_INCLUDES="-isystem $LLVM_SYSROOT/usr/include/c++/v1/ -isystem $LLVM_SYSROOT/usr/${MUSL_TRIPLE}/include/ "
-
-ENV COMMON_RUSTFLAGS="-Clinker=clang -Clink-args=-fuse-ld=lld -Lnative=${LLVM_SYSROOT}/usr/lib/"
-ENV SHARED_RUSTFLAGS="${COMMON_RUSTFLAGS}"
-ENV STATIC_RUSTFLAGS="${COMMON_RUSTFLAGS} -Ctarget-feature=+crt-static -Clink-args=-static \
-                      -Clink-args=-nodefaultlibs -Clink-args=-nostdlib -Clink-args=-nostdlib++\
-                      -Clink-args=-stdlib=c++ -Clink-args=-static-libgcc -l static=c++\
-                      -Clink-args=-static-libstdc++"
-
-ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="${STATIC_RUSTFLAGS} -Clink-args=--target=aarch64-unknown-linux-musl"
-ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="${STATIC_RUSTFLAGS} -Clink-args=--target=x86_64-unknown-linux-musl"
-
-ENV CC_${MUSL_TRIPLE}="clang"
-ENV CFLAGS_${MUSL_TRIPLE}="--target=${MUSL_TRIPLE} -fuse-ld=lld -static -fPIC -nostdlib -nodefaultlibs -nostdinc ${MUSL_C_INCLUDES} -L ${LLVM_SYSROOT}/usr/${MUSL_TRIPLE}/lib -lc  -L ${LLVM_SYSROOT}/usr/lib/linux/ -lclang_rt.builtins-${CROSS_COMPILER_TARGET_ARCH}"
-ENV CXX_${MUSL_TRIPLE}="clang++"
-ENV CXXFLAGS_${MUSL_TRIPLE}="--target=${MUSL_TRIPLE} -fuse-ld=lld -nostdinc -static-libstdc++ --stdlib=c++ --rtlib=compiler-rt -nodefaultlibs -nostdinc++ ${MUSL_CXX_INCLUDES} ${MUSL_C_INCLUDES}"
-
-ENV PCRE2_SYS_STATIC=1
-ENV SYSTEMD_LIB_DIR="/lib/${CROSS_COMPILER_TARGET_ARCH}-linux-gnu"
 
 ## Install static Zlib
 ARG ZLIB_VERSION=1.2.12
@@ -164,5 +127,12 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     cp -r include/* /usr/include/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/ && \
     sccache --show-stats && \
     rm -R /tmp/rocksdb/
+
+ENV CC_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_musl=${CROSS_COMPILER_TARGET_ARCH}-linux-musl-gcc \
+    CXX_${CROSS_COMPILER_TARGET_ARCH}_unknown_linux_musl=${CROSS_COMPILER_TARGET_ARCH}-linux-musl-g++ \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc
+
+ENV PCRE2_SYS_STATIC=1
 
 CMD ["bash"]


### PR DESCRIPTION
Environment variables that are relevant for llvm/clang were added to the Dockerfile when they shouldn't have been when I was rebasing. These break the static builds on 3.3/3.4/master