### PR TITLE
Build sccache from source

### DIFF
--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -17,8 +17,7 @@ ARG SCCACHE_ENDPOINT
 ARG SCCACHE_RECACHE
 ARG SCCACHE_SERVER_PORT=4226
 
-RUN rustup target add "${!TARGETARCH}-unknown-linux-musl"  && \
-    chmod -R a+rw $RUSTUP_HOME $CARGO_HOME
+RUN rustup target add "${!TARGETARCH}-unknown-linux-musl"
 
 RUN dpkg --add-architecture ${TARGETARCH} && \
     dpkg --add-architecture ${!CROSS_COMPILER_TARGET_ARCH} && \
@@ -29,11 +28,15 @@ ENV CFLAGS_aarch64_unknown_linux_musl="-isystem /usr/include/aarch64-linux-musl"
 ENV CC_x86_64_unknown_linux_musl=clang
 ENV CFLAGS_x86_64_unknown_linux_musl="-isystem /usr/include/x86_64-linux-musl"
 
-# Add cargo-flamegraph and cargo-cache
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
-    if [ -z "$SCCACHE_BUCKET" ]; then unset RUSTC_WRAPPER; fi; \
-    if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi; \
     mkdir -p /out/tools && \
+    # Install sccache for this image \
+    cargo install -q sccache --root "/usr/local" --no-default-features --features s3,azure,openssl/vendored && \
+    if [ -n "$SCCACHE_BUCKET" ]; then export RUSTC_WRAPPER=/usr/local/bin/sccache; fi && \
+    if [ -z "$SCCACHE_ENDPOINT" ]; then unset SCCACHE_ENDPOINT; fi && \
+    # Add sccache cargo-flamegraph, cargo-audit and cargo-cache \
+    cargo install -q sccache --root "opt/tools" --no-default-features --features s3,azure,openssl/vendored \
+        --target=${!TARGETARCH}-unknown-linux-musl && \
     cargo install -q --git https://github.com/flamegraph-rs/flamegraph \
         --tag v0.5.1 --locked --root /out/tools \
         --target=${!TARGETARCH}-unknown-linux-musl && \
@@ -44,6 +47,9 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
         --no-default-features --features vendored-openssl,vendored-libgit2 \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     sccache --show-stats
+
+ENV RUSTC_WRAPPER="/usr/local/bin/sccache"
+ENV CC_WRAPPER="/usr/local/bin/sccache"
 
 ENV LINUX_HEADER_VERSION="4.19.88"
 ARG MUSL_VERSION="1.2.2"
@@ -217,6 +223,9 @@ ARG SCCACHE_SERVER_PORT=4226
 ARG CROSS_COMPILER_TARGET_ARCH
 ENV LLVM_SYSROOT="/sysroot/${CROSS_COMPILER_TARGET_ARCH}-musl"
 ENV MUSL_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl"
+
+ENV RUSTC_WRAPPER="/usr/local/bin/sccache"
+ENV CC_WRAPPER="/usr/local/bin/sccache"
 
 # Copy files around to ensure changes are compatible with agent 3.3 and 3.4
 RUN mkdir -p /usr/local/rocksdb/${CROSS_COMPILER_TARGET_ARCH}-linux-musl/include && \

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -68,21 +68,6 @@ RUN curl -L https://sh.rustup.rs -sSf | \
     sh -s -- -q -y --default-toolchain $VERSION --component clippy rustfmt --profile minimal --no-modify-path && \
     chmod -R a+rw $RUSTUP_HOME $CARGO_HOME
 
-# Install sccache
-RUN cd /tmp \
-    && ARCH=$(uname -m) \
-    && curl -L https://api.github.com/repos/mozilla/sccache/releases/latest \
-    | grep "browser_download_url" \
-    | grep -E "sccache-v.*${ARCH}-unknown-linux-musl.tar.gz\"$" \
-    | awk '{$1=$1;print}' \
-    | cut -f2 -d" " \
-    | xargs curl -LO \
-    && mkdir -p /tmp/sccache \
-    && tar -C /tmp/sccache --strip-components=1 -xf /tmp/sccache-*-${ARCH}-unknown-linux-musl.tar.gz \
-    && mv /tmp/sccache/sccache /usr/local/bin/sccache \
-    && chmod +x /usr/local/bin/sccache \
-    && rm -rf /tmp/*
-
 ## Set up default cargo env vars for cross compiling
 ENV GNU_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-gnu"
 ENV MUSL_TRIPLE="${CROSS_COMPILER_TARGET_ARCH}-unknown-linux-musl"
@@ -113,8 +98,5 @@ ENV CC_x86_64_unknown_linux_gnu="clang"
 ENV CFLAGS_x86_64_unknown_linux_gnu="--target=x86_64-unknown-linux-gnu -fuse-ld=lld -fPIC"
 ENV CXX_x86_64_unknown_linux_gnu="clang++"
 ENV CXXFLAGS_x86_64_unknown_linux_gnu="--target=x86_64-unknown-linux-gnu -fuse-ld=lld -fPIC"
-
-ENV RUSTC_WRAPPER="/usr/local/bin/sccache"
-ENV CC_WRAPPER="/usr/local/bin/sccache"
 
 CMD ["bash"]


### PR DESCRIPTION
Sccache has released a new version, 0.3. Unfortunately they havn't distributed binaries with the new release, so we need to build it ourselves