### PR TITLE
Install Code Coverage Reporting Tool

### DIFF
--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -60,6 +60,9 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
         --no-default-features --features vendored-openssl,vendored-libgit2 \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     echo "built build image cargo-audit" && \
+    cargo install -q cargo-tarpaulin --version 0.21.0 --locked --root /out/tools \
+        --target=${!TARGETARCH}-unknown-linus-musl && \
+    echo "built build image cargo-tarpaulin" && \
     sccache --show-stats
 
 ENV RUSTC_WRAPPER="/usr/local/bin/sccache"

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -60,7 +60,6 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
         --no-default-features --features vendored-openssl,vendored-libgit2 \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     echo "built build image cargo-audit" && \
-    export OPENSSL_DIR=/usr/bin/openssl && \
     cargo install -q cargo-tarpaulin --version 0.21.0 --locked --root /out/tools \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     echo "built build image cargo-tarpaulin" && \

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -30,9 +30,6 @@ ENV CFLAGS_x86_64_unknown_linux_musl="-isystem /usr/include/x86_64-linux-musl"
 
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     mkdir -p /out/tools && \
-    cargo install -q cargo-tarpaulin --version 0.21.0 --locked --root /out/tools \
-        --target=${!TARGETARCH}-unknown-linus-musl && \
-    echo "built build image cargo-tarpaulin" && \
     # Install sccache for this image \
     cargo install -q sccache --root "/usr/local" --no-default-features --features s3,azure,openssl/vendored && \
     echo "installed build build image sccache" && \
@@ -63,6 +60,10 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
         --no-default-features --features vendored-openssl,vendored-libgit2 \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     echo "built build image cargo-audit" && \
+    cargo install -q cargo-kcov --version 0.5.2 --locked --root /out/tools \
+        --target=${!TARGETARCH}-unknown-linus-musl && \
+    cargo kcov --print-install-kcov-sh | sh && \
+    echo "built build image cargo-kcov" && \
     sccache --show-stats
 
 ENV RUSTC_WRAPPER="/usr/local/bin/sccache"

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -60,10 +60,9 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
         --no-default-features --features vendored-openssl,vendored-libgit2 \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     echo "built build image cargo-audit" && \
-    cargo install -q cargo-kcov --version 0.5.2 --locked --root /out/tools \
-        --target=${!TARGETARCH}-unknown-linus-musl && \
-    cargo kcov --print-install-kcov-sh | sh && \
-    echo "built build image cargo-kcov" && \
+    cargo install -q cargo-tarpaulin --version 0.21.0 --locked --root /out/tools \
+        --target=${!TARGETARCH}-unknown-linux-musl && \
+    echo "built build image cargo-tarpaulin" && \
     sccache --show-stats
 
 ENV RUSTC_WRAPPER="/usr/local/bin/sccache"

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -60,6 +60,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
         --no-default-features --features vendored-openssl,vendored-libgit2 \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     echo "built build image cargo-audit" && \
+    export OPENSSL_DIR=/usr/bin/openssl && \
     cargo install -q cargo-tarpaulin --version 0.21.0 --locked --root /out/tools \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     echo "built build image cargo-tarpaulin" && \

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -60,7 +60,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
         --no-default-features --features vendored-openssl,vendored-libgit2 \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     echo "built build image cargo-audit" && \
-    cargo install -q cargo-tarpaulin --version 0.21.0 --locked --root /out/tools \
+    cargo install cargo-tarpaulin --version 0.21.0 --locked --root /out/tools \
         --target=${!TARGETARCH}-unknown-linus-musl && \
     echo "built build image cargo-tarpaulin" && \
     sccache --show-stats

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -60,9 +60,10 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
         --no-default-features --features vendored-openssl,vendored-libgit2 \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     echo "built build image cargo-audit" && \
-    cargo install -q cargo-tarpaulin --version 0.21.0 --locked --root /out/tools \
+    cargo install -q cargo-kcov --version 0.5.2 --locked --root /out/tools \
         --target=${!TARGETARCH}-unknown-linux-musl && \
-    echo "built build image cargo-tarpaulin" && \
+    cargo kcov --print-install-kcov-sh | sh && \ 
+    echo "built build image cargo-kcov" && \
     sccache --show-stats
 
 ENV RUSTC_WRAPPER="/usr/local/bin/sccache"

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -30,6 +30,9 @@ ENV CFLAGS_x86_64_unknown_linux_musl="-isystem /usr/include/x86_64-linux-musl"
 
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     mkdir -p /out/tools && \
+    cargo install -q cargo-tarpaulin --version 0.21.0 --locked --root /out/tools \
+        --target=${!TARGETARCH}-unknown-linus-musl && \
+    echo "built build image cargo-tarpaulin" && \
     # Install sccache for this image \
     cargo install -q sccache --root "/usr/local" --no-default-features --features s3,azure,openssl/vendored && \
     echo "installed build build image sccache" && \
@@ -60,9 +63,6 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
         --no-default-features --features vendored-openssl,vendored-libgit2 \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     echo "built build image cargo-audit" && \
-    cargo install cargo-tarpaulin --version 0.21.0 --locked --root /out/tools \
-        --target=${!TARGETARCH}-unknown-linus-musl && \
-    echo "built build image cargo-tarpaulin" && \
     sccache --show-stats
 
 ENV RUSTC_WRAPPER="/usr/local/bin/sccache"

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -38,7 +38,8 @@ RUN DEPS="ca-certificates curl file m4 make locales pkg-config xz-utils cmake \
           llvm-${LLVM_MAJOR_VERSION} lld-${LLVM_MAJOR_VERSION} \
           libc++-${LLVM_MAJOR_VERSION}-dev lldb-${LLVM_MAJOR_VERSION}\
           systemd libsystemd-dev patch osslsigncode \
-          libssl-dev bzip2 gcc g++ libtool m4 libc6-dev libcap-dev" \
+          libssl-dev bzip2 gcc g++ libtool m4 libc6-dev libcap-dev \
+          libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev jq" \
   && apt-get update  > /dev/null \
   && apt-key add /llvm-snapshot.gpg.key \
   && apt-get install -y --no-install-recommends software-properties-common > /dev/null \

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -38,8 +38,7 @@ RUN DEPS="ca-certificates curl file m4 make locales pkg-config xz-utils cmake \
           llvm-${LLVM_MAJOR_VERSION} lld-${LLVM_MAJOR_VERSION} \
           libc++-${LLVM_MAJOR_VERSION}-dev lldb-${LLVM_MAJOR_VERSION}\
           systemd libsystemd-dev patch osslsigncode \
-          libssl-dev bzip2 gcc g++ libtool m4 libc6-dev libcap-dev \
-          libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev jq" \
+          libssl-dev bzip2 gcc g++ libtool m4 libc6-dev libcap-dev" \
   && apt-get update  > /dev/null \
   && apt-key add /llvm-snapshot.gpg.key \
   && apt-get install -y --no-install-recommends software-properties-common > /dev/null \

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -36,9 +36,10 @@ RUN DEPS="ca-certificates curl file m4 make locales pkg-config xz-utils cmake \
           lsof procps git automake hunspell-en-gb hunspell-tools linux-perf \
           texinfo procps zlib1g-dev clang-${LLVM_MAJOR_VERSION} \
           llvm-${LLVM_MAJOR_VERSION} lld-${LLVM_MAJOR_VERSION} \
-          libc++-${LLVM_MAJOR_VERSION}-dev lldb-${LLVM_MAJOR_VERSION}\
+          libc++-${LLVM_MAJOR_VERSION}-dev lldb-${LLVM_MAJOR_VERSION} \
           systemd libsystemd-dev patch osslsigncode \
-          libssl-dev bzip2 gcc g++ libtool m4 libc6-dev libcap-dev" \
+          libssl-dev bzip2 gcc g++ libtool m4 libc6-dev libcap-dev \
+          libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev jq" \
   && apt-get update  > /dev/null \
   && apt-key add /llvm-snapshot.gpg.key \
   && apt-get install -y --no-install-recommends software-properties-common > /dev/null \


### PR DESCRIPTION
This installs [cargo-kcov](https://github.com/kennytm/cargo-kcov), a code coverage reporting tool that outputs report in HTML format. Was looking at this as an alternative to `cargo-tarpaulin`. 