### PR TITLE
Bump Zlib Version

### DIFF
--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -166,7 +166,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
 
 
 ## Install static Zlib
-ARG ZLIB_VERSION=1.2.12
+ARG ZLIB_VERSION=1.2.13
 
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     if [ -z "$SCCACHE_BUCKET" ]; then unset CC_WRAPPER; fi; \


### PR DESCRIPTION
Zlib released their latest version on October, 13th. This was causing our builds to break because the old URL (with 1.2.13)  was returning a 404. This bumps `ZLIB_VERSION` to latest which version which fixes the error. 