### PR TITLE
Add llvm-tools-preview Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 ## CI Generated Images
 The CI job for this repo will generate tooling images with cross compilers
-targetting aarch64 and x86_64 for both linux/amd64 and linux/arm64
+targeting aarch64 and x86_64 for both linux/amd64 and linux/arm64
 platforms.
 
 Images are pushed by default by jobs on the main branch. Images on other
 branches can be pushed by setting the PUBLISH_GCR_IMAGE and/or
-PUBLISH_DOCKER_IMAGE params on the Jenkins build job
+PUBLISH_DOCKER_IMAGE params on the Jenkins build job.
 
 ### Image Tagging
 
 On all branches the image tags are appended with the git sha of the current
-revision. On main an additional tag without the trailing sha is also pushed
+revision. On main an additional tag without the trailing sha is also pushed.
 
 ## Helper scripts
 >  ./scripts/mk.debian

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -93,7 +93,7 @@ ARG VERSION="stable"
 # Install rust
 ENV CARGO_HOME=/opt/rust/cargo
 RUN curl -L https://sh.rustup.rs -sSf | \
-    sh -s -- -q -y --default-toolchain $VERSION --component clippy rustfmt --profile minimal --no-modify-path && \
+    sh -s -- -q -y --default-toolchain $VERSION --component clippy --component llvm-tools-preview rustfmt --profile minimal --no-modify-path && \
     chmod -R a+rw $RUSTUP_HOME $CARGO_HOME
 
 ## Set up default cargo env vars for cross compiling


### PR DESCRIPTION
Adds the `llvm-tools-preview` component which is needed for generating code coverage reports downstream. 