### PR TITLE
Enable sparse cargo registry protocol

### DIFF
--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -310,4 +310,6 @@ ENV PKG_CONFIG_ALLOW_CROSS=true \
     LIBZ_SYS_STATIC=1 \
     PLATFORM_LDFLAGS="-static-libstdc++ -static-libgcc"
 
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
 CMD ["bash"]

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -127,4 +127,6 @@ ENV CFLAGS_x86_64_unknown_linux_gnu="--target=x86_64-unknown-linux-gnu -fuse-ld=
 ENV CXX_x86_64_unknown_linux_gnu="clang++"
 ENV CXXFLAGS_x86_64_unknown_linux_gnu="--target=x86_64-unknown-linux-gnu -fuse-ld=lld -fPIC"
 
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
 CMD ["bash"]


### PR DESCRIPTION
This enables the cargo registry's "sparse" protocol which dramatically speeds up syncing the cargo registry