### PR TITLE
feat!: support bookworm target builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
           }
           axis {
             name 'VARIANT_VERSION'
-            values 'buster', 'bullseye'
+            values 'bullseye', 'bookworm'
           }
           // Host architecture of the built image
           axis {
@@ -125,7 +125,7 @@ pipeline {
           }
           axis {
             name 'VARIANT_VERSION'
-            values 'buster', 'bullseye'
+            values 'bullseye', 'bookworm'
           }
         }
         agent {
@@ -162,7 +162,7 @@ pipeline {
           }
           axis {
             name 'VARIANT_VERSION'
-            values 'buster', 'bullseye'
+            values 'bullseye', 'bookworm'
           }
           // Target ISA for musl cross comp toolchain and precompiled libs
           axis {
@@ -310,7 +310,7 @@ pipeline {
           }
           axis {
             name 'VARIANT_VERSION'
-            values 'buster', 'bullseye'
+            values 'bullseye', 'bookworm'
           }
           // Target ISA for musl cross comp toolchain and precompiled libs
           axis {

--- a/rust/debian/Dockerfile
+++ b/rust/debian/Dockerfile
@@ -51,9 +51,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     cargo binstall -y -q cargo-llvm-cov --no-symlinks --install-path /out/tools \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     echo "built build image cargo-llvm-cov" && \
-    cargo binstall -y -q cargo-xwin \
-        --pkg-url="{ repo }/releases/download/v{ version }/{ name }-v{ version }.{ target }.{ archive-format }" \
-        --version 0.16 --no-symlinks --install-path /out/tools \
+    cargo binstall -y -q cargo-xwin --version 0.16 --locked --no-symlinks --install-path /out/tools \
         --target=${!TARGETARCH}-unknown-linux-musl && \
     echo "built build image cargo-xwin" && \
     cargo binstall -y -q cargo-tarpaulin --version 0.27 --no-symlinks --install-path /out/tools \
@@ -115,7 +113,7 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     make install-headers
 
 # Configure cmake for building llvm headers, compiler-rt and builtins
-ENV CMAKE_COMMAND="cmake -q --parallel=$(nproc) --log-level=WARNING -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_INSTALL_MESSAGE=NEVER"
+ENV CMAKE_COMMAND="cmake --log-level=WARNING -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_INSTALL_MESSAGE=NEVER"
 ENV CMAKE_HOST_ARGS="-DCMAKE_INSTALL_PREFIX=${LLVM_SYSROOT}/usr -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld"
 ENV CMAKE_HOST="$CMAKE_COMMAND $CMAKE_HOST_ARGS"
 ENV CMAKE_TARGET=${CROSS_COMPILER_TARGET_ARCH}-linux-musl

--- a/rust/debian/Dockerfile.base
+++ b/rust/debian/Dockerfile.base
@@ -78,14 +78,14 @@ RUN if [[ "${VARIANT_VERSION}" != "buster" ]] ; then \
     mkdir -pm755 /etc/apt/keyrings && wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key && \
     wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/"${VARIANT_VERSION}"/winehq-"${VARIANT_VERSION}".sources && \
     apt update -y && \
-    apt install -y meson valac-bin valac valac-0.48-vapi libgsf-1-dev bats bison libgcab-dev libgirepository1.0-dev winehq-stable && \
-    git clone --recurse-submodules https://github.com/GNOME/msitools.git && \
+    apt install -y meson valac-bin valac libgsf-1-dev bats bison libgcab-dev libgirepository1.0-dev winehq-stable && \
+    git clone --depth 1 --branch v0.103 --recurse-submodules https://github.com/GNOME/msitools.git && \
     mkdir ./msitools/target && pushd ./msitools/target && \
     meson .. && ninja install && popd && rm -rf ./msitools && ldconfig && wixl --version && \
     mkdir ./miniconda && curl --retry 10 -sSfL https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Linux-$(uname -m).sh -o ./miniconda/setup.sh && \
     bash ./miniconda/setup.sh -b -p /opt/miniconda3 && rm -rf ./miniconda && \
     source /opt/miniconda3/etc/profile.d/conda.sh && conda install -y pytest flask && \
-    apt autoremove -y meson valac-bin valac valac-0.48-vapi bats bison > /dev/null && \
+    apt autoremove -y meson valac-bin valac bats bison > /dev/null && \
     apt-get clean > /dev/null && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc; \
     fi

--- a/scripts/mk.debian
+++ b/scripts/mk.debian
@@ -8,10 +8,14 @@ export DOCKER_BUILDKIT=1
 #
 #   linux/amd64       x86_64
 #   linux/arm64       aarch64
-declare -A platforms=( ["x86_64"]="linux/amd64" ["aarch64"]="linux/arm64")
+declare -A platforms=(["x86_64"]="linux/amd64" ["aarch64"]="linux/arm64")
 
 # Default to the host ARCH
 HOST_ARCH="$(uname -m)"
+
+if [ "$HOST_ARCH" = "arm64" ]; then
+  HOST_ARCH="aarch64"
+fi
 
 SUPPORTED_TARGETS="aarch64 x86_64"
 DEFAULT_VARIANT="bullseye"


### PR DESCRIPTION
Brings our debian support up-to-date with bookworm.

This also includes the following small changes:
* Remove `--parallel` and `-q` from cmake commands since latest version of cmake doesn't allow them in non-build contexts
* Remove `valac-0.48-vapi` dependency when building msi tools.
* Constrain msi tools to v0.103 instead of HEAD.
* Treat arm64 hosts (M4 mac's) as aarch64 hosts.
* Use `--locked` when installing cargo-xwin to pull correct dependency versions

BREAKING CHANGE: support for buster target builds dropped
Signed-off-by: Jacob Hull <jacob@planethull.com>